### PR TITLE
Add missing files in the project/ (or build fails after git clone)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+target/
+
+.dotty-ide-artifact
+.dotty-ide.json

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.3.4")


### PR DESCRIPTION
When running the `sbt update` (or `sbt compile`) just after cloning the repository it fails because it can not download dotty.
Plus added a minimal `.gitignore` not to have build artifacts in git.