### PR TITLE
Updated .rst files in docs directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # dotty-cps-async
 
 
-This is the implementation of async/await transformation for Scala3 (Dotty), based on an optimized version of cps[continuation passing style] transformation, where continuation is ‘pushed’ to the monad. 
+This is the implementation of async/await transformation for [Scala 3][scala3] (Dotty), based on an optimized version of [cps] (*continuation passing style*) transformation, where continuation is ‘pushed’ to the monad. 
 
-## Highlightings:
+## Highlightings
 
- * Full support of all scala language constructs in async/await block.
+ * Full support of all Scala language constructs in async/await block.
  * Pluggable monad interface:  
-    *  An await monad can be any trait, for which it is possible to implement [CpsAsyncMonad](https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala) typeclass. You can provide those methods for your favorite monad.
+    *  An await monad can be any trait for which it is possible to implement [`CpsAsyncMonad`](https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala) type class. You can provide those methods for your favorite monad.
  * Limited support of high-order functions:
-    * ```urls.map(fetchData(_))(await _ )```  is an idiomatic way to fetch data for all items in parallel.
+    * ```urls.map(fetchData(_))(await _ )``` is an idiomatic way to fetch data for all items in parallel.
     * An application developer or library author can provide 'shifted' implementation of the own high-order functions.
  * Optional features, which enhance ergonomics in some cases, such as automatic coloring and handling discarded values
- * Optional SIP-22 compatible API.
+ * Optional [SIP-22 compatible API][sip_22].
 
-For more details, please, look at the documentation: https://rssh.github.io/dotty-cps-async/
+For more details, please, read the documentation at https://rssh.github.io/dotty-cps-async/.
 
 
 ## Presentations
 
-* Scala3 & Async: Behing Futures.
+* Scala3 & Async: Behind Futures.
    * Svitla Smart Talk. https://www.youtube.com/watch?v=fBcGhjM2s-c (Apr. 2021. In Ukrainian language).
 
-* Can we free concurrent programming from the monadic style:
+* Can we free concurrent programming from the monadic style?
     * ScalaR:  https://www.youtube.com/watch?v=ImlUuTQUeaQ  (Jun 2020)
     * ScalaUA: https://www.youtube.com/watch?v=w-noRPLxYoA&t=3s  (Apr. 2020)
    (slides: https://www.slideshare.net/rssh1/can-concurrent-functional-programming-be-liberated-from-monadic-style )
 
-
-   
+[cps]: https://en.wikipedia.org/wiki/Continuation-passing_style
+[scala3]: https://dotty.epfl.ch/
+[sip_22]: https://docs.scala-lang.org/sips/async.html

--- a/docs/AsyncStreams.rst
+++ b/docs/AsyncStreams.rst
@@ -1,32 +1,42 @@
 
 Generators
-===================
+==========
 
 Async Streaming
 ---------------
 
-Generator syntax is a way to deliver values into some form of a stream asynchronously.
+The generator syntax is a way to deliver values into some form of a stream asynchronously.
 
 
 Example:
 
 .. code-block:: scala
-  import cps.*
-  import cps.monads.{*,given}
-  import cps.stream.*
 
-  asyncStream[AsyncList[Future,Int]]{ out =>
-     out.emit(0)
-     for(i <- 1 to 10)
-       out.emit(i)
-  }
+  import scala.concurrent.{Await, Future}
+  import scala.concurrent.ExecutionContext.Implicits.global
+  import scala.concurrent.duration.Duration
+  import cps.*                  // asyncStream, await
+  import cps.monads.{*, given}  // support for build-in monads (i.e. Future)
+  import cps.stream.*           // AsyncList, takeListAll
+
+  object Example:
+  
+    def main(args: Array[String]): Unit =
+      asyncStream[AsyncList[Future, Int]] { out =>
+      out.emit(0)
+      for i <- 1 to 10 do out.emit(i)
+    }
+    val f = stream.takeListAll()
+    val res = Await.result(f, Duration(1, "seconds"))
+    println(s"res=$res")
 
 
-Here `AsyncList <https://rssh.github.io/dotty-cps-async/api/jvm/api/cps/stream.AsyncList.html>`_ is a minimal implementation of async stream supplied with dotty-cps-async.
-Exists integration modules for well-known async streaming libraries (see :ref:`Integrations`).
+I recommend you try |AsyncList|_.
 
-The input to asyncStream is a block of code, which should be a lambda-expression that accepts an emitter argument.
-I.e., simplified definition looks next:
+Here |AsyncList|_ is a minimal implementation of async stream supplied with |dotty-cps-async|_.
+Exists integration modules for well-known async streaming libraries (see section :ref:`Integrations`).
+
+The input to |asyncStream|_ is a block of code, which should be a lambda-expression that accepts an emitter argument; i.e., the simplified definition looks as follows :
 
 .. code-block:: scala
 
@@ -34,28 +44,53 @@ I.e., simplified definition looks next:
 
 
 For a full definition, look at the source:
-  - `asyncStream <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncStream.scala>`_  - entry point for macro
-  - `CpsAsyncEmitAbsorber <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitAbsorber.scala>`_  - is an adapter from a generator to a stream of the given type.
-  - `CpsAsyncEmitter <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitter.scala>`_ is a trait with operations `emit`, which should be called inside asyncStream or async block. 
+
+- |asyncStream|_ is the entry point for macro
+- |CpsAsyncEmitAbsorber[R]|_ is an adapter from a generator to a stream of the given type.
+- |CpsAsyncEmitter|_ is a trait with operations ``emit``, which should be called inside |asyncStream|_ or |async|_ block. 
 
 
 Writing generator adapters for custom streams
---------------------------------------------
+---------------------------------------------
  
 To allow generator syntax for your stream, you need to implement 
- `CpsAsyncEmitAbsorber[R] <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitter.scala#L46>`_ where `evalAsync` accept cps-transformed function and output the result stream.
+ |CpsAsyncEmitAbsorber[R]|_ where ``evalAsync`` accepts a cps-transformed function and outputs the result stream.
  
-Dotty-cps-async provide a platform-specific trait `BaseUnfoldCpsAsyncEmitAbsorber` which can simplicify generator implementations for streams which has something like `unfoldAsync[S,E](s:S)(f:S => F[Option[(S,E)]]):R`.
+|dotty-cps-async|_ provides a platform-specific trait ``BaseUnfoldCpsAsyncEmitAbsorber`` which can simplicify generator implementations for streams which has something like ``unfoldAsync[S,E](s:S)(f:S => F[Option[(S,E)]]):R``.
 
-For example, looks at the implementation of CpsAsyncEmitAbsorber for Akka-stream Source:
+For example, look at the implementation of |CpsAsyncEmitAbsorber[R]|_ for |Akka Streams|_ source:
 
 .. code-block:: scala
 
    given AkkaStreamEmitAbsorber[T](using ExecutionContext):  
-                                BaseUnfoldCpsAsyncEmitAbsorber[Source[T,NotUsed],Future,T] with 
+                                BaseUnfoldCpsAsyncEmitAbsorber[Source[T, NotUsed], Future, T] with 
 
-      override type Element = T
+     override type Element = T
 
-      def unfold[S](s0:S)(f:S => Future[Option[(T,S)]]): Source[T, NotUsed] =
-        Source.unfoldAsync[S,T](s0)((s) => f(s).map(_.map{ case (x,y) => (y,x) }) )
+     def unfold[S](s0:S)(f: S => Future[Option[(T, S)]]): Source[T, NotUsed] =
+       Source.unfoldAsync[S, T](s0)((s) => f(s).map(_.map{ case (x, y) => (y, x) }) )
 
+
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+
+.. |Akka Streams| replace:: **Akka Streams**
+.. _Akka Streams: https://doc.akka.io/docs/akka/current/stream/
+
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala
+
+.. |AsyncList| replace:: ``cps.stream.AsyncList``
+.. _AsyncList: https://rssh.github.io/dotty-cps-async/api/jvm/api/cps/stream.AsyncList.html
+
+.. |asyncStream| replace:: ``asyncStream``
+.. _asyncStream: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncStream.scala
+
+.. |CpsAsyncEmitAbsorber[R]| replace:: ``CpsAsyncEmitAbsorber[R]``
+.. _CpsAsyncEmitAbsorber[R]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitAbsorber.scala
+
+.. |CpsAsyncEmitter| replace:: ``CpsAsyncEmitter``
+.. _CpsAsyncEmitter: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitter.scala
+
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async

--- a/docs/AutomaticColoring.rst
+++ b/docs/AutomaticColoring.rst
@@ -4,39 +4,38 @@ Automatic Coloring
 Overview
 -------- 
 
-Sometimes, especially when we work with distributes systems, most API call are asynchronous and should be prefixed by `await`.  And we should remember what functions we should call async and what - not.  It is known as 'async coloring problem': i.e. we should split our code technically into two parts (colors):  one works with async expressions (i.e.,, F[T]) and one - sync. (T without F).
+Sometimes, especially when we work with distributed systems, most API calls are asynchronous and should be prefixed by ``await``.  And we should remember what functions we should call async and what - not.  It is known as 'async coloring problem': i.e. we should split our code technically into two parts (colors):  one works with async expressions (i.e., ``F[T]``) and one - sync. (``T`` without ``F``).
 
-If we want to put asynchronous expression into synchronous function, we should write `await(expr)`  instead `expr`,  for transforming synchronous code into asynchronous.
-(see http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/ for more detailed explanation )
+If we want to put an asynchronous expression into a synchronous function, we should write ``await(expr)`` instead of ``expr``, for transforming synchronous code into asynchronous
+(see http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/ for more detailed explanation).
 
-
-In scala, we have types, so why not ask the compiler to do async coloring automatically?
-So, next code:
+In Scala, we have types, so why not ask the compiler to do async coloring automatically?
+So, the code below
 
 .. code-block:: scala
 
-  async[Future]{
-     val url = "http://www.example.com"
-     val data = await(api.fetchUrl("http://www.example.com"))
-     val theme = api.classifyText(data)
-     val dmpInfo: String = await(api.retrieveDMPInfo(url, await(theme), "1"))
-     dmpInfo
+  async[Future] {
+    val url = "http://www.example.com"
+    val data = await(api.fetchUrl("http://www.example.com"))
+    val theme = api.classifyText(data)
+    val dmpInfo: String = await(api.retrieveDMPInfo(url, await(theme), "1"))
+    dmpInfo
   }
 
 
-Can be written without await as:
+can be written without ``await`` as:
 
 .. code-block:: scala
 
    import cps.automaticColoring.given  
 
-   val c = async[Future]{
-        val url = "http://www.example.com"
-        val data = api.fetchUrl("http://www.example.com")
-        val theme = api.classifyText(data)
-        val dmpInfo: String = api.retrieveDMPInfo(url, theme, "1")
-        dmpInfo
-     }
+   val c = async[Future] {
+     val url = "http://www.example.com"
+     val data = api.fetchUrl("http://www.example.com")
+     val theme = api.classifyText(data)
+     val dmpInfo: String = api.retrieveDMPInfo(url, theme, "1")
+     dmpInfo
+   }
 
 
 Automatic Coloring & Memoization
@@ -45,23 +44,23 @@ Automatic Coloring & Memoization
 If the underlying monad supports execution caching for using this feature (i.e., two awaits on the same expression should not cause reevaluation), then implicit await is enough for automatic coloring.  But what to do with pure effect monads, which holds computations without starting them?
 
 
-Let's look at the next code:
+Let's look at the following code:
 
 .. code-block:: scala
 
 
-  def updateCounter(counter:Counter) = async[IO]{
+  def updateCounter(counter: Counter) = async[IO] {
     val value = counter.increment()
     if value % LOG_MOD == 0 then
-       log(s"counter value = ${await(value)}")
+      log(s"counter value = ${await(value)}")
     if (value - 1 == LOG_TRESHOLD) then
-       // Conversion will not be appliyed for == . 
-       // For this example we want automatic conversion, so -1
-       log("counter TRESHOLD")
+      // Conversion will not be appliyed for == . 
+      // For this example we want automatic conversion, so -1
+      log("counter TRESHOLD")
   }
 
 
-Assume IO is some pure effect monad, which holds a computation function that will be evaluated each time we need to get value from the monad. Counter.increment() is an IO action:  
+Assume IO is some pure effect monad, which holds a computation function that will be evaluated each time we need to get value from the monad. ``Counter.increment()`` is an IO action:  
 
 
 .. code-block:: scala
@@ -72,31 +71,31 @@ Assume IO is some pure effect monad, which holds a computation function that wil
 
 
 The compiler will insert awaits when testing and printing value. 
-For making two using of `val value` be the same value, we need to memoize value during the creation of `val`. 
+For making two using of `val value` be the same value, we need to memoize value during the creation of ``val``. 
 Otherwise, the counter will be incremented three times instead of one.
 
 Signature of memoization operation can be different for different monads; this can be:
-   * `memoize: F[X] => F[X]`  for imperative monads.
-   * `memoize: F[X] => F[F[X]]`  for pure effect monads.  Internal `F[_]` holds cached computation. External `F[_]` - operation of getting a result from received cache. Flattening this expressin will return the original computation.
+   * ``memoize: F[X] => F[X]``  for imperative monads.
+   * ``memoize: F[X] => F[F[X]]``  for pure effect monads.  Internal ``F[_]`` holds cached computation. External ``F[_]`` - operation of getting a result from received cache. Flattening this expressin will return the original computation.
 
 
-If we want to provide support for automatic coloring for your monad, you should implement CpsMonadMemoization trait, which can be one of:
- * CpsMonadMemoization.Default - if computations are cached in your monad by default.
- * CpsMonadMemoization.Inplace - for imperative monads
- * CpsMonadMemoization.Pure - for pure effect monads.
- * CpsMonadMemoization.Dynamic - for monads with custom memoization, which resolved with call-side types.
+If we want to provide support for automatic coloring for your monad, you should implement the |CpsMonadMemoization[F]|_ trait, which can be one of:
+ * ``CpsMonadMemoization.Default`` - if computations are cached in your monad by default.
+ * ``CpsMonadMemoization.Inplace`` - for imperative monads
+ * ``CpsMonadMemoization.Pure`` - for pure effect monads.
+ * ``CpsMonadMemoization.Dynamic`` - for monads with custom memoization, which resolved with call-side types.
 
 
 Safety rules for using memoized effect.
 ---------------------------------------
 
-  Safety rules for variable memoization are enforced with the help of additional preliminary analysis. If some variable is used only in a synchronous context (i.e., via await), it should be colored as synchronous (i.e., cached). If some variable is passed to other functions as effect - it should be colored asynchronous (i.e., uncached). If the variable is used in both synchronous and asynchronous contexts, we can't deduce the programmer’s intention and report an error.
+Safety rules for variable memoization are enforced with the help of additional preliminary analysis. If some variable is used only in a synchronous context (i.e., via ``await``), it should be colored as synchronous (i.e., cached). If some variable is passed to other functions as effect - it should be colored asynchronous (i.e., uncached). If the variable is used in both synchronous and asynchronous contexts, we can't deduce the programmer’s intention and report an error.
 
 Preliminary analysis using next algorithm:
 
- * For each invocation of a variable inside async block - count the number of calls with and without awaits.
- * If we have a call with await, then using the same variable in ia call without await reported as an error (and vice-versa)
- * If the variable, defined outside of the async block, is used in synchronous context more than once - the macro also will report an error.
+* For each invocation of a variable inside ``async`` block - count the number of calls with and without awaits.
+* If we have a call with await, then using the same variable in ia call without await reported as an error (and vice-versa)
+* If the variable, defined outside of the async block, is used in synchronous context more than once - the macro also will report an error.
 
 
 Custom value discard
@@ -106,7 +105,7 @@ Custom value discard
 
 During the writing of asynchronous code, typical developers’ mistakes are to forget to handle something connected with discarded values, like error processing or awaiting.  
 
-``cps.customValueDiscard``  limit the value discarding in the non-final expression in the block.  When enabled, value discarding is allowed only for those types T, for which exists an implementation of a special ValueDiscard[T]. If given ValueDiscard[T] is not found in the current scope, then dropping values of this type is prohibited.  If found - ValueDiscard.apply(t) is called. It's defined as a no-op for primitive types and can be extended by the developer for its own types.
+``cps.customValueDiscard`` limits the value discarding in the non-final expression in the block.  When enabled, value discarding is allowed only for those types ``T``, for which exists an implementation of a special |ValueDiscard[T]|_. If given ``ValueDiscard[T]`` is not found in the current scope, then dropping values of this type is prohibited.  If found - ``ValueDiscard.apply(t)`` is called. It's defined as a no-op for primitive types and can be extended by the developer for its own types.
 
 Example:
 
@@ -115,11 +114,11 @@ Assume we have next api:
 .. code-block:: scala
 
  object api:
-   def  fetch(url: string): Future[String]
-   def  dryRun(data:string): Future[Unit] 
-   def  processData(data:string): Future[String]
+   def fetch(url: String): Future[String]
+   def dryRun(data: String): Future[Unit] 
+   def processData(data: String): Future[String]
  
-Where the semantics of `dryRun`  - raise an error if it is impossible to run processData().
+Where the semantics of ``dryRun``  - raise an error if it is impossible to run ``processData()``.
 
 Let's look at the next code:
 
@@ -129,9 +128,9 @@ Let's look at the next code:
  import cps.customValueDiscard
 
  val c = async[Future] {
-    val data = await(api.fetch("http://www.example.com"))
-    dryRun(data)
-    await(process(data))
+   val data = await(api.fetch("http://www.example.com"))
+   dryRun(data)
+   await(process(data))
  } 
 
 
@@ -146,9 +145,8 @@ If you want to see warning instead error, you can import `warnValueDiscard` feat
  //import cps.warnValueDiscard.given  //  < 0.9.3
  import cps.warnValueDiscard
 
-Note that custom value discarding is automatically enabled for effect monads to prevent situations where discarding values
- drop branches in the computation flow.
-Let's look again at the code:
+
+Note that custom value discarding is automatically enabled for effect monads to prevent situations where discarding values drop branches in the computation flow. Let's look again at the code:
 
 .. code-block:: scala
 
@@ -156,20 +154,36 @@ Let's look again at the code:
     val value = counter.increment()
     if value % LOG_MOD == 0 then
        log(s"counter value = ${await(value)}")
-    if (value - 1 == LOG_TRESHOLD) then
+    if value - 1 == LOG_TRESHOLD then
        // Conversion will not be appliyed for == . For this example we want automatic conversion, so -1
        log("counter TRESHOLD")
   }
 
-Assuming that logging is IO operation, i.e. log have signature
+Assuming that logging is IO operation, i.e. function ``log`` has the signature
 
 .. code-block:: scala
 
-   def log(message:String): IO[Unit]
+   def log(message: String): IO[Unit]
 
 
-Without custom value discarding, the log statement will be dropped.  (Type of `if` with one branch is 'Unit', so type of the first branch should be 'Unit', so log statement will be discarded).
-Dotty-cps-async provides special `AwaitValueDiscard <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/ValueDiscard.scala#L27>`_  which forces monad to be evaluated before being discarded.  We recommend use this discard as default for IO[Unit].
+Without custom value discarding, the log statement will be dropped.  (Type of ``if`` with one branch is |Unit|_, so type of the first branch should be |Unit|_, so log statement will be discarded).
+|dotty-cps-async|_ provides special |AwaitValueDiscard|_  which forces monad to be evaluated before being discarded.  We recommend use this discard as default for ``IO[Unit]``.
 
 
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
+.. |AwaitValueDiscard| replace:: ``AwaitValueDiscard``
+.. _AwaitValueDiscard: https://github.com/rssh/dotty-cps-async/blob/ff25b61f93e49a1ae39df248dbe4af980cd7f948/shared/src/main/scala/cps/ValueDiscard.scala#L44
+
+.. |CpsMonadMemoization[F]| replace:: ``CpsMonadMemoization[F]``
+.. _CpsMonadMemoization[F]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadMemoization.scala
+
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |Unit| replace:: ``Unit``
+.. _Unit: https://www.scala-lang.org/api/current/scala/Unit.html
+
+.. |ValueDiscard[T]| replace:: ``ValueDiscard[T]``
+.. _ValueDiscard[T]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/ValueDiscard.scala

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -1,10 +1,10 @@
 Additional Features
 ===================
 
-Short syntax for await
-----------------------
+Short syntax for ``await``
+--------------------------
 
-It can be helpful when monad or environment does not support automatic coloring, but the default `await` syntax is too heavy.  For this case, we define `unary_!` operator for use instead of `await`. 
+It can be helpful when monad or environment does not support automatic coloring, but the default ``await`` syntax is too heavy.  For this case, we define the |unary_!|_ operator for use instead of ``await``. 
 
 Example:
 
@@ -15,48 +15,63 @@ Example:
     val x = username + !fetchToken(data)
 
 
-Inside the async block this will be a synonim for
+Inside the async block this will be a synonym for
 
 .. code-block:: scala
 
     val x = username + await(fetchToken(data))
 
 
-
-
-
-SIP22-compatible interface
-----------------------------
+SIP-22 compatible interface
+---------------------------
 
 .. index:: sip22
 
-This feature provides a compatibility layer for Scala2 `SIP-22 <https://docs.scala-lang.org/sips/async.html>`_ 
-`async <https://github.com/scala/scala-async>`_. 
-When migrating your program from legacy SIP22 to dotty, you can change the headers, from
+This feature provides a compatibility layer for Scala 2 |SIP-22|_ (implementated in |scala-async|_). 
+When migrating your program from legacy SIP-22 to Scala 3, you can change the headers, from
 
 .. code-block:: scala
 
- import scala.async.Async.{async,await}
+ import scala.async.Async.{async, await}
 
 to
 
 .. code-block:: scala
 
- import cps.compat.sip22.{async,await}
+ import cps.compat.sip22.{async, await}
 
-and use Future based async/await.
+and use |Future|_-based async/await.
 
-All test cases from the original Scala-Async distribution are passed with a change of imports only,
+All test cases from the original |scala-async|_ distribution are passed with a change of imports only,
 and included in our regression suite.
 
-It is also possible to compile sip22 async code without changing of the source code with `shim--scala-async--dotty-cps-async <https://github.com/rssh/shim--scala-async--dotty-cps-async>`_ -s help. 
+It is also possible to compile |SIP-22|_ code without changing of the source code with |shim--scala-async--dotty-cps-async|_ -s help. 
 
 .. code-block:: scala
 
  libraryDependencies += "com.github.rssh" %% "shim-scala-async-dotty-cps-async" % "0.9.5",
 
 
-Note that compatibility was not a primary goal during the development of dotty-cps-async. Generated code is quite different, so if you need a bug-to-bug compatible version of scala2 async, you should use the port of the original -XAsync compiler plugin.
+Note that compatibility was not a primary goal during the development of |dotty-cps-async|_. The generated code is quite different, so if you need a bug-to-bug compatible version of Scala 2 |scala-async|_, you should use the port of the original ``-XAsync`` compiler plugin.
 
 
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |Future| replace:: ``Future``
+.. _Future: https://www.scala-lang.org/api/current/scala/concurrent/Future.html
+
+.. |SIP-22| replace:: **SIP-22 async**
+.. _SIP-22: https://docs.scala-lang.org/sips/async.html
+
+.. |scala-async| replace:: ``scala-async``
+.. _scala-async: https://github.com/scala/scala-async
+
+.. |shim--scala-async--dotty-cps-async| replace:: ``shim--scala-async--dotty-cps-async``
+.. _shim--scala-async--dotty-cps-async: https://github.com/rssh/shim--scala-async--dotty-cps-async
+
+.. |unary_!| replace:: ``unary_!``
+.. _unary_!: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/syntax/package.scala

--- a/docs/HighOrderFunctions.rst
+++ b/docs/HighOrderFunctions.rst
@@ -1,15 +1,14 @@
 High-order functions.
 =====================
 
-Dotty-cps-async supports the automatic transformation of high-order functions,  where the lambda expression argument contains ``await``.  
+|dotty-cps-async|_ supports the automatic transformation of high-order functions, where the lambda expression argument contains ``await``.  
 
-For example, let us have a list of remote servers and fetch some data from them. 
-Assume  that our http client provides the next interface:
+For example, assume an HTTP client provides the following interface to fetch some data from a list of remote servers.
 
 .. code-block:: scala
 
  trait HttpClient:
-    def fetchData(url: String): Future[String] 
+   def fetchData(url: String): Future[String] 
 
 
 Then we can fetch data from all servers just by using ``await`` in the ``map`` argument:
@@ -19,7 +18,7 @@ Then we can fetch data from all servers just by using ``await`` in the ``map`` a
      urls.map( await(httpClient.fetchData(_)) )
 
 
-Note that the default ``map`` will run all operations sequentially. Sequential evaluation is needed to allow the code to work correctly for a case of updating the multidimensional array in for loop with asynchronous operations.
+Note that the default ``map`` method will run all operations sequentially. Sequential evaluation is needed to allow the code to work correctly for a case of updating the multidimensional array in a ``for`` loop with asynchronous operations.
 
 If we want all requests to run in parallel, we can start them in one map and, when all started - wait for the end of requests:
 
@@ -27,90 +26,92 @@ If we want all requests to run in parallel, we can start them in one map and, wh
 
        urls.map( httpClient.fetchData(_) ).map(await(_))
 
-During async transform, dotty-cps-async substitute method map of you List with signature  
-   ``List[A].map[B](f: A=>B)`` to  
+During async transform, |dotty-cps-async|_ substitutes method ``map`` with signature ``List[A].map[B](f: A => B)`` to  
 
 .. index:: AsyncShift
 
 .. code-block:: scala
 
- summon[AsyncShift[List[A]]].map[F[_],B](c,summon[CpsMonad[F]])
+ summon[AsyncShift[List[A]]].map[F[_], B](c, summon[CpsMonad[F]])
                     
 
 which is implemented in cps runtime with signature
 
 .. code-block:: scala
 
-   AsyncShift[List[A]].map[F[_],B](obj:List[A],cpsMonad:CpsMonad[F])(f: A=> F[B])
+   AsyncShift[List[A]].map[F[_], B](obj: List[A], cpsMonad: CpsMonad[F])(f: A => F[B])
 
 
-Dotty-cps-async includes implementations of shifted methods for most of the standard library objects. So, it is possible to write something like ``x=cache.getOrElse( await(fetchData() )`` .
+|dotty-cps-async|_ includes implementations of shifted methods for most objects of the Scala standard library.
+
+So, we can write something like
+
+.. code-block:: scala
+
+  val x = cache.getOrElse( await(fetchData() )
 
 
 How to provide shifted functions.
---------------------------------
+---------------------------------
 
 
 Functional interface.
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Suppose you want to make high-order methods of your class ``C`` be able to accept lambda functions with await. 
-In that case, you should implement the ``given AsynsShift[C]`` typeclass with a shifted version of your high-order methods.  
-Such a 'shifted' version has an additional type parameter: ``F[_]``  and an additional list of arguments, inserted first, containing the original object instance and an appropriative ``CpsMonad[F]``.  
+Suppose you want to make high-order methods of your class ``C`` be able to accept lambda functions with ``await``. 
+For that purpose you have to implement the |given AsyncShift[C]|_ type class with a shifted version of your high-order methods.  
+Such a 'shifted' version has an additional type parameter ``F[_]`` and an additional list of arguments, inserted first, containing the original object instance and an appropriate |CpsMonad[F]|_.  
 
 
 Parameters should be changed in the following way:
 
-* If the origin parameter has type  ``A=>B``, then changed: ``A => F[B]``
-* If the origin parameter is called by name with type ``=>A``, then changed: ``()=>F[A]``
-* Otherwise, the changed parameter has the same type as the origin.
+* If the original parameter has type  ``A => B``, then changed: ``A => F[B]``
+* If the original parameter is called by name with type ``=> A``, then changed: ``() => F[A]``
+* Otherwise, the changed parameter has the same type as the original.
 
 
 Example:
 
 .. code-block:: scala
 
- case class TaggedValue[T](tag: String, value:  T)
-      def   modified[S](f: T => S): TaggedValue[S] =
-          TaggedValue(tag, f(x))
+ case class TaggedValue[T](tag: String, value: T)
+   def modified[S](f: T => S): TaggedValue[S] =
+     TaggedValue(tag, f(x))
 
  class TaggedValueAsyncShift[T] extends AsyncShift[TaggedValue[T]]:
-
-      def modified[F[_],S](o:TaggedValue[T], m: CpsMonad[F])(f: T=>F[S]): F[TaggedValue[S]] =
-          f(value).map(TaggedValue(tag,_))
+   def modified[F[_], S](o: TaggedValue[T], m: CpsMonad[F])(f: T => F[S]): F[TaggedValue[S]] =
+     f(value).map(TaggedValue(tag,_))
              
  object TaggedValue:
+   transparent inline given shiftedTaggedValue[T] as AsyncShift[TaggedValue[T] =
+     TaggedValueAsyncShift[T]() 
 
-      transparent inline given shiftedTaggedValue[T] as AsyncShift[TaggedValue[T] =
-                                                                               TaggedValueAsyncShift[T]() 
 
-
-Object oriented interface.
+Object-oriented interface.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes, we can use classes, defines in an object-oriented manner, where data is private inside class.  If the developer of such a class wants to provide API for dotty-cps-async, then he/she can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside your class:
-
+In some cases, we use classes – defined in an object-oriented manner – with private data.  If we wants a class to provide an API for `dotty-cps-async <https://github.com/rssh/dotty-cps-async#dotty-cps-async>`_, then we can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside our class:
 
 Example:
 
 .. code-block:: scala
 
- class  MyIntController:
-    private var x:  Int = 0;
+ class MyIntController:
+   private var x: Int = 0
 
-    def  modify(f: Int => Int): Int =
-       val old = x
-       x = f(x)
-       sendSignal(x)
-       old
+   def modify(f: Int => Int): Int =
+     val old = x
+     x = f(x)
+     sendSignal(x)
+     old
 
-    def modify_async[F[_]](m: CpsMonad[M])(f: Int => F[Int]): F[Int] =
-       val old = x
-       m.map(f(x))(_ => { sendSignal(x); old }) 
+   def modify_async[F[_]](m: CpsMonad[M])(f: Int => F[Int]): F[Int] =
+     val old = x
+     m.map(f(x))(_ => { sendSignal(x); old }) 
 
 
-As we have seen, shifted functions have an additional type parameter: F[_] and parameter CpsMonad[F]  (or more specific type, if needed).  Async transformer will substitute the call of `modify` into `modify_async` during compilation.
-   Sometimes,  we already have F[_] as the type parameter of the enclosing class. We can omit those additional parameters in the async variant in such a case.
+As we have seen, shifted functions have an additional type parameter: ``F[_]`` and a parameter |CpsMonad[F]|_ (or more specific type, if needed).  Async transformer will substitute the call of ``modify`` into ``modify_async`` during compilation.
+   Sometimes, we already have ``F[_]`` as the type parameter of the enclosing class. We can omit those additional parameters in the async variant in such a case.
 
 Note that you should carefully decide whether you need async function support and how to deal with concurrent modifications.  For example, in the code snippet below, different changes will interleave with each other.
  Usually, low-level constructs do not need async counterparts.
@@ -119,58 +120,59 @@ Note that you should carefully decide whether you need async function support an
 .. _substitutions-in-call-chains:
 
 Special semantics for substitutions in call chains
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-  Consider a chain of calls, which accepts async-shifted functions.  One example is  'withFilter' from the standard collections library.  Let's look ath the next code:  
-
-.. code-block:: scala
-
-  for{ url ← urls if  await(status(url))==Active
-        items ← await(api.retrieveItems(url))
-        Item <- items
-     } yield item  
-
-
-Here usual semantics of `withFilter` assume that we iterate `urls` only once.  But if we will translate this expression according to standard rules, we will receive two passes: one pass in async `withFilter` and the second in `flatMap`.
-
-To perform iteration once, we translate `withFilter` not to F[WithFilter] but to a substituted type DelayedWithFilter , which holds the received predicate and delays actual evaluation upon the call of the next operation in the chain.
-
-The implementation of this class looks like:
+Consider a chain of calls, which accepts async-shifted functions.  One example is ``withFilter`` from the standard collections library.  Let's look at the following code:  
 
 .. code-block:: scala
 
- class DelayedWithFilter[F[_], A, C[X] <: Iterable[X], CA <: C[A]](c: CA,
-                                         m: CpsMonad[F],
-                                         p:A=>F[Boolean],
-                                         ) 
-                  extends CallChainAsyncSubst[F, WithFilter[A,C], F[WithFilter[A,C]] ]
+  for {
+    url <- urls if await(status(url)) == Active
+    items <- await(api.retrieveItems(url))
+    Item <- items
+  } yield item  
+
+
+Here usual semantics of ``withFilter`` assume that we iterate over ``urls`` only once.  But if we translate this expression according to the standard rules, we will receive two passes: one pass in async ``withFilter`` and the second in ``flatMap``.
+
+To perform the iteration once, we translate ``withFilter`` not to ``F[WithFilter]`` but to a substituted type ``DelayedWithFilter``, which holds the received predicate and delays actual evaluation upon the call of the next operation in the chain.
+
+The implementation of class ``DelayedWithFilter`` looks like:
+
+.. code-block:: scala
+
+ class DelayedWithFilter[F[_], A, C[X] <: Iterable[X], CA <: C[A]](
+     c: CA,
+     m: CpsMonad[F],
+     p: A => F[Boolean],
+ ) extends CallChainAsyncSubst[F, WithFilter[A, C], F[WithFilter[A, C]] ]
  {
-  // return eager copy
-  def _finishChain: F[WithFilter[A,C]] = ...
+   // return eager copy
+   def _finishChain: F[WithFilter[A, C]] = //...
 
-  def withFilter(q: A=>Boolean): DelayedWithFilter[F,A,CX,CA] =  ...
+   def withFilter(q: A => Boolean): DelayedWithFilter[F, A, CX, CA] = //...
 
-  def withFilter_async(q: A=> F[Boolean]) = ...
+   def withFilter_async(q: A=> F[Boolean]) = //...
 
-  def map[B](f: A => B): F[C[B]] = ...
+   def map[B](f: A => B): F[C[B]] = //...
 
-  def map_async[B](f: A => F[B]): F[C[B]] = ...
+   def map_async[B](f: A => F[B]): F[C[B]] = //...
 
-  def flatMap[B](f: A => IterableOnce[B]): F[C[B]] = ...
+   def flatMap[B](f: A => IterableOnce[B]): F[C[B]] = //...
 
-  def flatMap_async[B](f: A => F[IterableOnce[B]]): F[C[B]] = ...
+   def flatMap_async[B](f: A => F[IterableOnce[B]]): F[C[B]] = //...
 
-  def foreach[U](f: A=>U): F[Unit] = ...
+   def foreach[U](f: A => U): F[Unit] = //...
 
-  def foreach_async[U](f: A=>F[U]): F[Unit] = ...
+   def foreach_async[U](f: A => F[U]): F[Unit] = //...
 
  }
 
 
-I.e., in delayed variant, all original class methods should or collect operations into the next delayed object or perform an actual batched call.   
-Also, we have the method `_finishChain`,  which is called when we have no next call in the chain: an example of such a case is   `val x = c.withFilter(p)`.  
+I.e., in delayed variant, all original methods should or collect operations into the next delayed object or perform an actual batched call.   
+Also, we have the method ``_finishChain``,  which is called when we have no next call in the chain; an example of such a case is ``val x = c.withFilter(p)``.  
 
-By convention, the substituted type should be derived from CallChainAsyncSubst[F,T] 
+By convention, the substituted type should be derived from ``CallChainAsyncSubst[F, T]``.
 
 
 This structure has a nice categorical interpretation. If you are curious about that, read details in :ref:`categorical-interpretation-for-CallChainAsyncSubst`.
@@ -179,34 +181,50 @@ This structure has a nice categorical interpretation. If you are curious about t
 Builder methods.
 ^^^^^^^^^^^^^^^^
 
-   Yet one common pattern of usage of hight-order functions is builder methods, where we use hight-order functions to build some processing algorithm.
+Yet one common usage pattern of high-order functions is builder methods, where we use high-order functions to build some processing algorithm.
 
 .. code-block:: scala
 
- trait ReadChannel[F,A]:
+ trait ReadChannel[F, A]:
 
-    def map(f: A=>B):  ReadChannel[F, B]
+   def map(f: A => B): ReadChannel[F, B]
 
 
-Here, `map` is using for building streaming interface. We can provide async variant of `map` wich will return the same type as original function:
+Here, method ``map`` is used for building the streaming interface. We can provide an async variant of ``map`` which will return the same type as the original function:
 
 .. code-block:: scala
 
- trait ReadChannel[F,A]:
+ trait ReadChannel[F, A]:
 
-    def map(f: A=>B):  ReadChannel[F, B]
+   def map(f: A => B): ReadChannel[F, B]
 
-    def mapAsync(f: A=>F[B]): ReadChannel[F, B]
+   def mapAsync(f: A => F[B]): ReadChannel[F, B]
 
 
-Also we can see, that our channel structure is already build on top of `F[_]`, so it is not necessory to pass F to method parameter.
+Also we can see that our channel structure is already build on top of ``F[_]``, so it is not necessary to pass ``F`` to method parameter.
  
-About name for `mapAsync` -- dotty-cps-async supports both variant: camelCase `mapAsync` and snake_case `map_async`. We propose to use next convention when naming such methods:  use `method_async` when async method unlikely will be called by programmer directly and used only for substitution in highg-order function; use `methodAsync` when we expect that developer can use this method directly along with cps substitution.
+For convenience `dotty-cps-async <https://github.com/rssh/dotty-cps-async#dotty-cps-async>`_ supports both naming variants of ``mapAsync``: camelCase ``mapAsync`` and snake_case ``map_async``.
+
+We propose to use next convention when naming such methods:
+
+- use ``method_async`` when the async method will unlikely be called directly by the programmer and will be used only for substitution in high-order function;
+- use ``methodAsync`` when we expect that developer can use this method directly along with cps substitution.
 
 
 Async high-order functional interfaces  
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
- For a case with an acynchronous high-order function interfaces (i.e., methods wich accept functions like `f:(A=>F[B])` ), the `async` macro can automatically transform the asynchronous result to have the same signature, so you can use awaits inside async lambdas without implementing additional methods or typeclasses.
+For a case with an asynchronous high-order function interface (i.e. methods which accept functions like ``f:(A => F[B])`` ), the ``async`` macro can automatically transform the asynchronous result to have the same signature, so you can use ``await`` calls inside async lambdas without implementing additional methods or type classes.
 
 
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+
+.. |CpsMonad[F]| replace:: ``CpsMonad[F]``
+.. _CpsMonad[F]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |given AsyncShift[C]| replace:: ``given AsyncShift[C]``
+.. _given AsyncShift[C]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncShift.scala

--- a/docs/Integrations.rst
+++ b/docs/Integrations.rst
@@ -1,84 +1,162 @@
-.._Integrations:
+.. _Integrations:
 
 Integrations
 ============
 
-dooty-cps-async itself provide type classes for monads, available without external dependencies: this is  `Future <https://https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/monads/FutureAsyncMonad.scala>`_ ,  JVM-only Java `CompletableFuture <https://github.com/rssh/dotty-cps-async/blob/master/jvm/src/main/scala/cps/monads/CompletableFutureCpsMonad.scala>`_ and JS-only `js.Promise <https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/PromiseCpsAwaitable.scala>`_  and `JSFuture <https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/jsfuture/JSFuture.scala>`_ .
+|dotty-cps-async|_ itself provides type classes for monads, available without external dependencies: this is  |FutureAsyncMonad|_ ,  JVM-only Java |CompletableFuture|_ and JS-only |js.Promise|_  and |JSFuture|_ .
 
  
 Third-party effect stacks are provided in external modules.
  
 
-cps-async-connect
------------------
+rssh/cps-async-connect
+----------------------
 
- github project: https://github.com/rssh/cps-async-connect
+GitHub project: https://github.com/rssh/cps-async-connect
 
 
-cats-effect
+Cats Effect
 ^^^^^^^^^^^
 
+Add dependency |cps-async-connect-cats-effect|_ to your ``build.sbt`` to integrate |Cats Effect|_ :
 
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-cats-effect" % "0.9.1"
+  libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.4"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-cats-effect" % "0.9.5"
 
 
-Note, that for cats-effect also exists https://github.com/typelevel/cats-effect-cps, integrated with typelevel stack.
+**Note**: Typelevel's project |cats-effect-cps|_ also provides async/await syntax support for |Cats Effect|_.
 
 
-monix
+Monix
 ^^^^^
 
+Add dependency |cps-async-connect-monix|_ to your ``build.sbt`` to integrate |Monix|_ :
+
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-monix" % "0.9.1"
+  libraryDependencies += "io.monix" %% "monix" % "3.4.0"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-monix" % "0.9.5"
 
 
-scalaz IO
+Scalaz IO
 ^^^^^^^^^
 
+Add dependency |cps-async-connect-scalaz|_ to your ``build.sbt`` to integrate |Scalaz IO|_ :
+
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-scalaz" % "0.9.1"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-scalaz" % "0.9.5"
 
 
 ZIO and ZIO Streams
 ^^^^^^^^^^^^^^^^^^^
 
+Add dependency |cps-async-connect-zio|_ to your ``build.sbt`` to integrate |ZIO|_ :
+
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-zio" % "0.9.1"
+  libraryDependencies += "dev.zio" %% "zio" % "2.0.0-RC1"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-zio" % "0.9.5"
 
 
 Akka Streams
-^^^^^^^^^^^^^
+^^^^^^^^^^^^
+
+Add dependency |cps-async-connect-akka-stream|_ to your ``build.sbt`` to integrate Lightbend's |Akka Streams|_ :
 
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-akka-stream" % "0.9.1"
+  libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.18"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-akka-stream" % "0.9.5"
 
 
-Fs2 Stream
-^^^^^^^^^^^^^
+FS2 Stream
+^^^^^^^^^^
+
+Add dependency |cps-async-connect-fs2|_ to your ``build.sbt`` to integrate Typelevel's |FS2|_ :
 
  .. code-block:: scala
 
-   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-fs2" % "0.9.1"
-
-
+  libraryDependencies += "co.fs2" %% "fs2-core" % "3.2.0"
+  libraryDependencies += "co.fs2" %% "fs2-io" % "3.2.0"
+  libraryDependencies += "com.github.rssh" %%% "cps-async-connect-fs2" % "0.9.5"
 
 
 typelevel/cats-effect-cps
 -------------------------
 
- Can be found on https://github.com/typelevel/cats-effect-cps   
- This is an experimental library to support uniform async/await syntax fori cats-effect in Scala2 and Scala3, integrated with typelevel ecosystem.
+GitHub project: https://github.com/typelevel/cats-effect-cps
+
+|cats-effect-cps|_ is an experimental library to support uniform async/await syntax for |Cats Effect|_ in Scala 2 and Scala 3, integrated with |Typelevel ecosystem|_.
 
 
 Call for additions:
 -------------------
 
-If you have implemented CpsMonad support for some effect stack and want to mention it here - please, send a pull request about this.
+If you have implemented |CpsMonad|_ support for some effect stack and want to mention it here - please, send a pull request about this.
 
 
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+
+.. |Akka Streams| replace:: **Akka Streams**
+.. _Akka Streams: <https://doc.akka.io/docs/akka/current/stream/
+
+.. |Cats Effect| replace:: **Cats Effect**
+.. _Cats Effect: https://typelevel.org/cats-effect/
+
+.. |cats-effect-cps| replace:: ``cats-effect-cps``
+.. _cats-effect-cps: https://github.com/typelevel/cats-effect-cps
+
+.. |CompletableFuture| replace:: ``CompletableFuture``
+.. _CompletableFuture: https://github.com/rssh/dotty-cps-async/blob/master/jvm/src/main/scala/cps/monads/CompletableFutureCpsMonad.scala
+
+.. |cps-async-connect-akka-stream| replace:: ``cps-async-connect-akka-stream``
+.. _cps-async-connect-akka-stream: https://github.com/rssh/cps-async-connect#akka-streams
+
+.. |cps-async-connect-cats-effect| replace:: ``cps-async-connect-cats-effect``
+.. _cps-async-connect-cats-effect: https://github.com/rssh/cps-async-connect#cats-effect
+
+.. |cps-async-connect-fs2| replace:: ``cps-async-connect-fs2``
+.. _cps-async-connect-fs2: https://github.com/rssh/cps-async-connect#fs2-streams
+
+.. |cps-async-connect-monix| replace:: ``cps-async-connect-monix``
+.. _cps-async-connect-monix: https://github.com/rssh/cps-async-connect#monix
+
+.. |cps-async-connect-scalaz| replace:: ``cps-async-connect-scalaz``
+.. _cps-async-connect-scalaz: https://github.com/rssh/cps-async-connect#scalaz-io
+
+.. |cps-async-connect-zio| replace:: ``cps-async-connect-zio``
+.. _cps-async-connect-zio: https://github.com/rssh/cps-async-connect#zio
+
+.. |CpsMonad| replace:: ``CpsMonad``
+.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |FS2| replace:: **FS2**
+.. _FS2: https://fs2.io/
+
+.. |FutureAsyncMonad| replace:: ``FutureAsyncMonad``
+.. _FutureAsyncMonad: https://https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/monads/FutureAsyncMonad.scala
+
+.. |JSFuture| replace:: ``JSFuture``
+.. _JSFuture: https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/jsfuture/JSFuture.scala
+
+.. |js.Promise| replace:: ``js.Promise``
+.. _js.Promise: https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/PromiseCpsAwaitable.scala
+
+.. |Monix| replace:: **Monix**
+.. _Monix: https://monix.io/
+
+.. |Scalaz IO| replace:: **Scalaz IO**
+.. _Scalaz IO: https://scalaz.github.io/
+
+.. |Typelevel ecosystem| replace:: **Typelevel ecosystem**
+.. _Typelevel ecosystem: https://typelevel.org/cats/typelevelEcosystem.html
+
+.. |ZIO| replace:: **ZIO**
+.. _ZIO: https://zio.dev/

--- a/docs/MonadsInteroperability.rst
+++ b/docs/MonadsInteroperability.rst
@@ -1,14 +1,16 @@
 Monads interoperability.
 ========================
 
-Monads in async and await can be different:  ``await[F]`` can be applied inside ``async[G]``  when exists 
-`CpsMonadConversion[F, G] <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadConversion.scala>`_.
+Monads in ``async`` and ``await`` can be different: ``await[F]`` can be applied inside ``async[G]``  when exists 
+|CpsMonadConversion[F, G]|_.
 
-Future Examples
----------------
+``Future`` Examples
+-------------------
 
-``async[F]{ await[Future](.. ) }``
-..................................
+``async[F]{ await[Future]( /*..*/ ) }``
+.......................................
+
+We first describe how to invoke ``await[Future]`` inside a ``async[F]`` block.
 
 Here is an example of implementation of ``Conversion`` from ``Future`` to any async monad ``G[_]`` :
 
@@ -16,9 +18,9 @@ Here is an example of implementation of ``Conversion`` from ``Future`` to any as
 .. code-block:: scala
 
  given fromFutureConversion[G[_]](using ExecutionContext, CpsAsyncMonad[G]): 
-                                                  CpsMonadConversion[Future,G] with
-     def apply[T](ft:Future[T]): G[T] =
-           summon[CpsAsyncMonad[G]].adoptCallbackStyle(
+                                                  CpsMonadConversion[Future, G] with
+   def apply[T](ft: Future[T]): G[T] =
+     summon[CpsAsyncMonad[G]].adoptCallbackStyle(
                                          listener => ft.onComplete(listener) )
 
 
@@ -33,30 +35,31 @@ Here 'async monad' for ``G[_]`` means it is possible to receive ``G[T]`` from a 
     * called by the source, which accept callback.
     * source is called immediatly in adoptCallbackStyle
     **/
-   def adoptCallbackStyle[A](source: (Try[A]=>Unit) => Unit): F[A]
+   def adoptCallbackStyle[A](source: (Try[A] => Unit) => Unit): F[A]
 
  }
 
 
-After making this definition available, we can await Future into any async monad:
+After making this definition available, we can await |Future|_ into any async monad:
 
 
 .. code-block:: scala
 
  def fun(x:Int):Future[Int] =
-       Future successful (x+1)
+   Future successful (x+1)
 
-     val c = async[ComputationBound]{
-       val a = await(fun(10))
-       a
-     }
+ val c = async[ComputationBound] {
+   val a = await(fun(10))
+   a
+ }
 
 
-``async[Future]{ await[F](.. ) }``
-..................................
+``async[Future]{ await[F]( /*..*/ ) }``
+.......................................
 
-And how about inserting ``await[F]`` into  ``async[Future]`` ?.
- For this it should mean, that our ``F`` should be able to schedule operation:
+And how about inserting ``await[F]`` into a ``async[Future]`` block ?
+
+For this it should mean, that our ``F`` should be able to schedule operation:
 
 .. code-block:: scala
 
@@ -66,27 +69,26 @@ And how about inserting ``await[F]`` into  ``async[Future]`` ?.
     * schedule execution of op somewhere.
     * Note, that characteristics of scheduler can vary.
     **/
-   def spawn[A](op: =>F[A]): F[A]
+   def spawn[A](op: => F[A]): F[A]
 
  }
 
 
-This can be immediatly evaluation for imperative monads, or for monads with delayed evaluation, 
-like haskell-like IO -- submittiong op to a pull, which should be evaluated during ```unsafePerformIO``` 
-at the end of the world.
+This can be immediatly evaluated for imperative monads, or for monads with delayed evaluation, 
+like Haskell-like IO -- submitting the ``op`` argument to a pull, which should be evaluated during ``unsafePerformIO`` at the end of the world.
 
-You can read implementation of conversion of scheduled monad to ``Future`` in  `FutureAsyncMonad.scala <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/FutureAsyncMonad.scala>`_ 
+You can read implementation of conversion of scheduled monad to |Future|_ in the source file |FutureAsyncMonad.scala|_.
 
-Of course, it is is possible to create other conversions between you monads, based on other principles.
+Of course, it is possible to create other conversions between your monads, based on other principles.
 
 js.Promise
 -----------
 
 Not only monads can be subject to await. For example, it is impossible to attach monad structure to ``js.Promise`` in scalajs, 
-because map operation is unimplementable: all ``Promise`` operation flatten their arguments.  But we can await ``Promise`` from scala
-``async[Future]`` blocks, because ``CpsMonadConversion[Future,Promise]`` is defined.
+because map operation is unimplementable: all ``Promise`` operations flatten their arguments.  But we can await ``Promise`` from Scala
+``async[Future]`` blocks, because ``CpsMonadConversion[Future, Promise]`` is defined.
 
-Also, for fluent implementation of JS facades, dotty-cps-async provides ``JSFuture`` trait, which has monadic operations in scala and visible from JavaScript as ``Promise``.  
+Also, for fluent implementation of JS facades, |dotty-cps-async|_ provides the |JSFuture|_ trait, which has monadic operations in Scala and visible from JavaScript as ``Promise``.  
 i.e. with the following definitions:
 
 .. code-block:: scala
@@ -98,11 +100,31 @@ i.e. with the following definitions:
 
    @JSExport
    def myFunction(x: String): JSFuture[String] = async[JSFuture] {
-       .... // can use await from futures and promises
+     // can use await from futures and promises
+     // ...
    }
 
 
-``FromScalaExampl.myFunction("string")``  can be used as ``Promise`` on javascript side.
+``FromScalaExample.myFunction("string")`` can be used as |Promise|_ on the JavaScript side.
 
 
+.. ###########################################################################
+.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
+.. |CpsMonadConversion[F, G]| replace:: ``CpsMonadConversion[F, G]``
+.. _CpsMonadConversion[F, G]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadConversion.scala
+
+.. |dotty-cps-async| replace:: **dotty-cps-async**
+.. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |Future| replace:: ``Future``
+.. _Future: https://www.scala-lang.org/api/current/scala/concurrent/Future.html
+
+.. |FutureAsyncMonad.scala| replace:: ``FutureAsyncMonad.scala``
+.. _FutureAsyncMonad.scala: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/monads/FutureAsyncMonad.scala
+
+.. |JSFuture| replace:: ``JSFuture``
+.. _JSFuture: https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/jsfuture/JSFuture.scala
+
+.. |Promise| replace:: ``Promise``
+.. _Promise: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#description

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,6 @@
-addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.1.0")
-addSbtPlugin("org.scala-js" % "sbt-scalajs"      % "1.8.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.8.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.0.1")
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.1.0")


### PR DESCRIPTION
Changes include : 
- corrected typos
- improved english grammar
- improved text formatting (e.g. verbatim)
- updated 2 code examples to be self-contained (i.e. run `scalac` and `scala` with appropriate options)
- added many external hyperlinks (see hyperlink section at the bottom of each .rst file)
