### PR TITLE
improved .rst files in docs (cnt'd)

### DIFF
--- a/docs/AsyncStreams.rst
+++ b/docs/AsyncStreams.rst
@@ -17,24 +17,24 @@ Example:
   import scala.concurrent.duration.Duration
   import cps.*                  // asyncStream, await
   import cps.monads.{*, given}  // support for build-in monads (i.e. Future)
-  import cps.stream.*           // AsyncList, takeListAll
+  import cps.stream.*           // AsyncList
 
   object Example:
   
     def main(args: Array[String]): Unit =
-      asyncStream[AsyncList[Future, Int]] { out =>
-      out.emit(0)
-      for i <- 1 to 10 do out.emit(i)
-    }
-    val f = stream.takeListAll()
-    val res = Await.result(f, Duration(1, "seconds"))
-    println(s"res=$res")
+      val stream = asyncStream[AsyncList[Future, Int]] { out =>
+        out.emit(0)
+        for i <- 1 to 10 do out.emit(i)
+      }
+      val f = stream.takeListAll()
+      val res = Await.result(f, Duration(1, "seconds"))
+      println(s"res=$res")
 
 
 I recommend you try |AsyncList|_.
 
 Here |AsyncList|_ is a minimal implementation of async stream supplied with |dotty-cps-async|_.
-Exists integration modules for well-known async streaming libraries (see section :ref:`Integrations`).
+There exist integration modules for well-known async streaming libraries (see section :ref:`Integrations`).
 
 The input to |asyncStream|_ is a block of code, which should be a lambda-expression that accepts an emitter argument; i.e., the simplified definition looks as follows :
 
@@ -56,7 +56,7 @@ Writing generator adapters for custom streams
 To allow generator syntax for your stream, you need to implement 
  |CpsAsyncEmitAbsorber[R]|_ where ``evalAsync`` accepts a cps-transformed function and outputs the result stream.
  
-|dotty-cps-async|_ provides a platform-specific trait ``BaseUnfoldCpsAsyncEmitAbsorber`` which can simplicify generator implementations for streams which has something like ``unfoldAsync[S,E](s:S)(f:S => F[Option[(S,E)]]):R``.
+|dotty-cps-async|_ provides a platform-specific trait |BaseUnfoldCpsAsyncEmitAbsorber|_ which can simplicify generator implementations for streams which has something like ``unfoldAsync[S, E](s: S)(f:S => F[Option[(S, E)]]): R``.
 
 For example, look at the implementation of |CpsAsyncEmitAbsorber[R]|_ for |Akka Streams|_ source:
 
@@ -67,24 +67,27 @@ For example, look at the implementation of |CpsAsyncEmitAbsorber[R]|_ for |Akka 
 
      override type Element = T
 
-     def unfold[S](s0:S)(f: S => Future[Option[(T, S)]]): Source[T, NotUsed] =
+     def unfold[S](s0: S)(f: S => Future[Option[(T, S)]]): Source[T, NotUsed] =
        Source.unfoldAsync[S, T](s0)((s) => f(s).map(_.map{ case (x, y) => (y, x) }) )
 
 
 .. ###########################################################################
-.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+.. ## Hyperlink definitions with text formatting (e.g. verbatim, bold)
 
 .. |Akka Streams| replace:: **Akka Streams**
 .. _Akka Streams: https://doc.akka.io/docs/akka/current/stream/
 
 .. |async| replace:: ``async``
-.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
 
 .. |AsyncList| replace:: ``cps.stream.AsyncList``
-.. _AsyncList: https://rssh.github.io/dotty-cps-async/api/jvm/api/cps/stream.AsyncList.html
+.. _AsyncList: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/AsyncList.scala
 
 .. |asyncStream| replace:: ``asyncStream``
-.. _asyncStream: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncStream.scala
+.. _asyncStream: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncStream.scala#L20
+
+.. |BaseUnfoldCpsAsyncEmitAbsorber| replace:: ``BaseUnfoldCpsAsyncEmitAbsorber``
+.. _BaseUnfoldCpsAsyncEmitAbsorber: https://github.com/rssh/dotty-cps-async/blob/master/jvm/src/main/scala/cps/stream/BaseUnfoldCpsAsyncEmitAbsorber.scala#L10
 
 .. |CpsAsyncEmitAbsorber[R]| replace:: ``CpsAsyncEmitAbsorber[R]``
 .. _CpsAsyncEmitAbsorber[R]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/stream/CpsAsyncEmitAbsorber.scala

--- a/docs/AutomaticColoring.rst
+++ b/docs/AutomaticColoring.rst
@@ -4,12 +4,12 @@ Automatic Coloring
 Overview
 -------- 
 
-Sometimes, especially when we work with distributed systems, most API calls are asynchronous and should be prefixed by ``await``.  And we should remember what functions we should call async and what - not.  It is known as 'async coloring problem': i.e. we should split our code technically into two parts (colors):  one works with async expressions (i.e., ``F[T]``) and one - sync. (``T`` without ``F``).
+Sometimes, especially when we work with distributed systems, most API calls are asynchronous and should be prefixed by |await|_.  And we should remember what functions we should call async and what - not.  It is known as 'async coloring problem': i.e. we should split our code technically into two parts (colors):  one works with async expressions (i.e., ``F[T]``) and one - sync. (``T`` without ``F``).
 
-If we want to put an asynchronous expression into a synchronous function, we should write ``await(expr)`` instead of ``expr``, for transforming synchronous code into asynchronous
+If we want to put an asynchronous expression into a synchronous function, we should write ``await(expr)`` instead of ``expr``, for transforming the synchronous code into an asynchronous one
 (see http://journal.stuffwithstuff.com/2015/02/01/what-color-is-your-function/ for more detailed explanation).
 
-In Scala, we have types, so why not ask the compiler to do async coloring automatically?
+In |Scala 3|_, we have types, so why not ask the compiler to do async coloring automatically?
 So, the code below
 
 .. code-block:: scala
@@ -23,7 +23,7 @@ So, the code below
   }
 
 
-can be written without ``await`` as:
+can be written without |await|_ as:
 
 .. code-block:: scala
 
@@ -48,7 +48,6 @@ Let's look at the following code:
 
 .. code-block:: scala
 
-
   def updateCounter(counter: Counter) = async[IO] {
     val value = counter.increment()
     if value % LOG_MOD == 0 then
@@ -71,29 +70,29 @@ Assume IO is some pure effect monad, which holds a computation function that wil
 
 
 The compiler will insert awaits when testing and printing value. 
-For making two using of `val value` be the same value, we need to memoize value during the creation of ``val``. 
+For making two using of ``val value`` be the same value, we need to memoize value during the creation of ``val``. 
 Otherwise, the counter will be incremented three times instead of one.
 
 Signature of memoization operation can be different for different monads; this can be:
-   * ``memoize: F[X] => F[X]``  for imperative monads.
-   * ``memoize: F[X] => F[F[X]]``  for pure effect monads.  Internal ``F[_]`` holds cached computation. External ``F[_]`` - operation of getting a result from received cache. Flattening this expressin will return the original computation.
+* ``memoize: F[X] => F[X]`` for imperative monads.
+* ``memoize: F[X] => F[F[X]]`` for pure effect monads.  Internal ``F[_]`` holds cached computation. External ``F[_]`` - operation of getting a result from received cache. Flattening this expressin will return the original computation.
 
 
 If we want to provide support for automatic coloring for your monad, you should implement the |CpsMonadMemoization[F]|_ trait, which can be one of:
- * ``CpsMonadMemoization.Default`` - if computations are cached in your monad by default.
- * ``CpsMonadMemoization.Inplace`` - for imperative monads
- * ``CpsMonadMemoization.Pure`` - for pure effect monads.
- * ``CpsMonadMemoization.Dynamic`` - for monads with custom memoization, which resolved with call-side types.
+* ``CpsMonadMemoization.Default`` - if computations are cached in your monad by default.
+* ``CpsMonadMemoization.Inplace`` - for imperative monads
+* ``CpsMonadMemoization.Pure`` - for pure effect monads.
+* ``CpsMonadMemoization.Dynamic`` - for monads with custom memoization, which resolved with call-side types.
 
 
 Safety rules for using memoized effect.
 ---------------------------------------
 
-Safety rules for variable memoization are enforced with the help of additional preliminary analysis. If some variable is used only in a synchronous context (i.e., via ``await``), it should be colored as synchronous (i.e., cached). If some variable is passed to other functions as effect - it should be colored asynchronous (i.e., uncached). If the variable is used in both synchronous and asynchronous contexts, we can't deduce the programmer’s intention and report an error.
+Safety rules for variable memoization are enforced with the help of additional preliminary analysis. If some variable is used only in a synchronous context (i.e., via |await|_), it should be colored as synchronous (i.e., cached). If some variable is passed to other functions as effect - it should be colored asynchronous (i.e., uncached). If the variable is used in both synchronous and asynchronous contexts, we can't deduce the programmer’s intention and report an error.
 
 Preliminary analysis using next algorithm:
 
-* For each invocation of a variable inside ``async`` block - count the number of calls with and without awaits.
+* For each invocation of a variable inside |async|_ block - count the number of calls with and without awaits.
 * If we have a call with await, then using the same variable in ia call without await reported as an error (and vice-versa)
 * If the variable, defined outside of the async block, is used in synchronous context more than once - the macro also will report an error.
 
@@ -105,7 +104,7 @@ Custom value discard
 
 During the writing of asynchronous code, typical developers’ mistakes are to forget to handle something connected with discarded values, like error processing or awaiting.  
 
-``cps.customValueDiscard`` limits the value discarding in the non-final expression in the block.  When enabled, value discarding is allowed only for those types ``T``, for which exists an implementation of a special |ValueDiscard[T]|_. If given ``ValueDiscard[T]`` is not found in the current scope, then dropping values of this type is prohibited.  If found - ``ValueDiscard.apply(t)`` is called. It's defined as a no-op for primitive types and can be extended by the developer for its own types.
+``cps.customValueDiscard`` limits the value discarding in the non-final expression in the block.  When enabled, value discarding is allowed only for those types ``T``, for which exists an implementation of a special |ValueDiscard[T]|_. If given |ValueDiscard[T]|_ is not found in the current scope, then dropping values of this type is prohibited.  If found - ``ValueDiscard.apply(t)`` is called. It's defined as a no-op for primitive types and can be extended by the developer for its own types.
 
 Example:
 
@@ -134,7 +133,7 @@ Let's look at the next code:
  } 
 
 
-Here developer forgott to wrap ``dryRun`` in ``await.``  But ``customValueDiscard`` feature is enabled and value discard operation is not defined for ```Future``, so this code will not compile.
+Here the developer forgot to wrap ``dryRun`` into |await|_.  But ``customValueDiscard`` feature is enabled and value discard operation is not defined for ```Future``, so this code will not compile.
 
 .. index:: warnValueDiscard
 
@@ -150,16 +149,16 @@ Note that custom value discarding is automatically enabled for effect monads to 
 
 .. code-block:: scala
 
-  def updateCounter(counter:Counter) = async[IO]{
+  def updateCounter(counter: Counter) = async[IO] {
     val value = counter.increment()
     if value % LOG_MOD == 0 then
-       log(s"counter value = ${await(value)}")
+      log(s"counter value = ${await(value)}")
     if value - 1 == LOG_TRESHOLD then
-       // Conversion will not be appliyed for == . For this example we want automatic conversion, so -1
-       log("counter TRESHOLD")
+      // Conversion will not be appliyed for == . For this example we want automatic conversion, so -1
+      log("counter TRESHOLD")
   }
 
-Assuming that logging is IO operation, i.e. function ``log`` has the signature
+Assuming that logging is an IO operation, i.e. function ``log`` has the signature
 
 .. code-block:: scala
 
@@ -171,7 +170,13 @@ Without custom value discarding, the log statement will be dropped.  (Type of ``
 
 
 .. ###########################################################################
-.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+.. ## Hyperlink definitions with text formatting (e.g. verbatim, bold)
+
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
 
 .. |AwaitValueDiscard| replace:: ``AwaitValueDiscard``
 .. _AwaitValueDiscard: https://github.com/rssh/dotty-cps-async/blob/ff25b61f93e49a1ae39df248dbe4af980cd7f948/shared/src/main/scala/cps/ValueDiscard.scala#L44
@@ -181,6 +186,9 @@ Without custom value discarding, the log statement will be dropped.  (Type of ``
 
 .. |dotty-cps-async| replace:: **dotty-cps-async**
 .. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
+
+.. |Scala 3| replace:: **Scala 3**
+.. _Scala 3: https://dotty.epfl.ch/
 
 .. |Unit| replace:: ``Unit``
 .. _Unit: https://www.scala-lang.org/api/current/scala/Unit.html

--- a/docs/BasicUsage.rst
+++ b/docs/BasicUsage.rst
@@ -23,7 +23,7 @@ Basic Usage
 
 The usage is quite similar to working with async/await frameworks in Scala 2 (e.g. |scala-async|_) and in other languages.
 
-We define two 'pseudo-functions' ``async`` and ``await`` [#f1]_ : 
+We define two 'pseudo-functions' |async|_ and |await|_ [#f1]_ : 
 
  .. index:: async
  .. index:: await
@@ -36,7 +36,7 @@ We define two 'pseudo-functions' ``async`` and ``await`` [#f1]_ :
 
 
 
-Inside the async block, we can use the ``await`` pseudo-function.
+Inside the async block, we can use the |await|_ pseudo-function.
 
 
  .. code-block:: scala
@@ -64,6 +64,7 @@ The minimal complete snippet looks as follows:
 
     import scala.concurrent.{Await, Future}
     import scala.concurrent.ExecutionContext.Implicits.global
+    import scala.concurrent.duration.Duration
     import scala.util.{Failure, Success}
     import cps.*                          //  async, await
     import cps.monads.{*, given}          //  support for build-in monads (i.e. Future)
@@ -83,7 +84,7 @@ The minimal complete snippet looks as follows:
         f.failed.map { ex => println(ex.getMessage) }
   
 
-This minimal example is for |Future|_ monad and depends on library |dotty-cps-async|_ which we need to add to our project file ``build.sbt`` :
+This minimal example is for |Future|_ monad and depends on library |dotty-cps-async|_ to be added to our project file ``build.sbt`` :
 
  .. code-block:: scala
 
@@ -115,7 +116,7 @@ Also monad can be abstracted out as in the following example:
         finally
           connection.close()
 
-Async macro will transform code inside ``async`` to something like
+Async macro will transform code inside |async|_ to something like
 
  .. raw:: html
 
@@ -153,13 +154,13 @@ Async macro will transform code inside ``async`` to something like
   </details>
 
 As transformation technique we use optimized monadic transform, the number of monadic brackets is the 
-same as the numer of ``await`` s in code.  
+same as the number of |await|_ s in the source code.  
 You can read the :ref:`notes about implementation details <random-notes>`.
 
 
 .. rubric:: Footnotes
 
-.. [#f1] The definitions are simplified, in reality they are more complex, because we want infer the type of expression independently from the type of monad.
+.. [#f1] The definitions are simplified, in reality they are more complex, because we want infer the type of the expression independently from the type of monad.
 
 
 .. ###########################################################################
@@ -168,11 +169,17 @@ You can read the :ref:`notes about implementation details <random-notes>`.
 .. |Akka Streams| replace:: **Akka Streams**
 .. _Akka Streams: https://doc.akka.io/docs/akka/current/stream/
 
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
+
 .. |Cats Effect| replace:: **Cats Effect**
 .. _Cats Effect: https://typelevel.org/cats-effect/
 
 .. |CpsMonad| replace:: ``CpsMonad``
-.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala#L20
 
 .. |CpsTryMonad| replace:: ``CpsTryMonad``
 .. _CpsTryMonad: https://github.com/rssh/dotty-cps-async/blob/ff25b61f93e49a1ae39df248dbe4af980cd7f948/shared/src/main/scala/cps/CpsMonad.scala#L70

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,14 +1,15 @@
 ## FAQ
 
 * What are the current limitations?
-    * all scala constructions are supported in async block. 
-* Can we use await inside the argument of the high-order function? (like map or filter).
-    * Yes, application developer or library author can provide ‘shifted’  implementation of the high-order function, which accepts  X=>M[Y] instead X=>Y.  This was previously implemented in the limited form in scala-gopher (paper: <https://arxiv.org/abs/1611.00602>)  for scala-2 and in practice, even in limited form, works quite well.
+    * All Scala constructs are supported in an [async] block. 
+* Can we use await inside the argument of the high-order function? (like ``map`` or ``filter``).
+    * Yes, an application developer or library author can provide ‘shifted’ implementation of the high-order function, which accepts ``X => M[Y]`` instead ``X => Y``.  This was previously implemented in the limited form in [scala-gopher] (paper: <https://arxiv.org/abs/1611.00602>)  for Scala 2 and in practice, even in limited form, works quite well.
 * I want to help with development. Where to start?
     * Open an issue (or select existing unassigned)  on GitHub and provide a preliminary plan for your work.  If you want to consult before choosing a task - ping me directly via e-mail or twitter.
-* Is exists a version for scala-2?
-    * No
+* Is exists a version for Scala 2?
+    * No.
 
+<!-- link refs -->
 
-
-   
+[async]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+[scala-gopher]: https://github.com/rssh/scala-gopher

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -4,7 +4,7 @@ Additional Features
 Short syntax for ``await``
 --------------------------
 
-It can be helpful when monad or environment does not support automatic coloring, but the default ``await`` syntax is too heavy.  For this case, we define the |unary_!|_ operator for use instead of ``await``. 
+It can be helpful when monad or environment does not support automatic coloring, but the default |await|_ syntax is too heavy.  For this case, we define the |unary_!|_ operator for use instead of |await|_. 
 
 Example:
 
@@ -15,7 +15,7 @@ Example:
     val x = username + !fetchToken(data)
 
 
-Inside the async block this will be a synonym for
+Inside the |async|_ block this will be a synonym for
 
 .. code-block:: scala
 
@@ -27,8 +27,8 @@ SIP-22 compatible interface
 
 .. index:: sip22
 
-This feature provides a compatibility layer for Scala 2 |SIP-22|_ (implementated in |scala-async|_). 
-When migrating your program from legacy SIP-22 to Scala 3, you can change the headers, from
+This feature provides a compatibility layer for Scala 2 |SIP-22|_ (implemented in |scala-async|_). 
+When migrating your program from legacy SIP-22 to Scala 3, you can change the imports from
 
 .. code-block:: scala
 
@@ -45,7 +45,7 @@ and use |Future|_-based async/await.
 All test cases from the original |scala-async|_ distribution are passed with a change of imports only,
 and included in our regression suite.
 
-It is also possible to compile |SIP-22|_ code without changing of the source code with |shim--scala-async--dotty-cps-async|_ -s help. 
+It is also possible to compile |SIP-22|_ code without changing the source code with |shim--scala-async--dotty-cps-async|_'s help. 
 
 .. code-block:: scala
 
@@ -56,7 +56,13 @@ Note that compatibility was not a primary goal during the development of |dotty-
 
 
 .. ###########################################################################
-.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+.. ## Hyperlink definitions with text formatting (e.g. verbatim, bold)
+
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
 
 .. |dotty-cps-async| replace:: **dotty-cps-async**
 .. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async

--- a/docs/HighOrderFunctions.rst
+++ b/docs/HighOrderFunctions.rst
@@ -1,7 +1,7 @@
 High-order functions.
 =====================
 
-|dotty-cps-async|_ supports the automatic transformation of high-order functions, where the lambda expression argument contains ``await``.  
+|dotty-cps-async|_ supports the automatic transformation of high-order functions, where the lambda expression argument contains |await|_.  
 
 For example, assume an HTTP client provides the following interface to fetch some data from a list of remote servers.
 
@@ -11,14 +11,14 @@ For example, assume an HTTP client provides the following interface to fetch som
    def fetchData(url: String): Future[String] 
 
 
-Then we can fetch data from all servers just by using ``await`` in the ``map`` argument:
+Then we can fetch data from all servers just by using |await|_ in the |map|_ argument:
 
 .. code-block:: scala
 
      urls.map( await(httpClient.fetchData(_)) )
 
 
-Note that the default ``map`` method will run all operations sequentially. Sequential evaluation is needed to allow the code to work correctly for a case of updating the multidimensional array in a ``for`` loop with asynchronous operations.
+Note that the default |map|_ method will run all operations sequentially. Sequential evaluation is needed to allow the code to work correctly for a case of updating the multidimensional array in a ``for`` loop with asynchronous operations.
 
 If we want all requests to run in parallel, we can start them in one map and, when all started - wait for the end of requests:
 
@@ -26,7 +26,7 @@ If we want all requests to run in parallel, we can start them in one map and, wh
 
        urls.map( httpClient.fetchData(_) ).map(await(_))
 
-During async transform, |dotty-cps-async|_ substitutes method ``map`` with signature ``List[A].map[B](f: A => B)`` to  
+During async transform, |dotty-cps-async|_ substitutes method |map|_ with signature ``List[A].map[B](f: A => B)`` to  
 
 .. index:: AsyncShift
 
@@ -35,14 +35,14 @@ During async transform, |dotty-cps-async|_ substitutes method ``map`` with signa
  summon[AsyncShift[List[A]]].map[F[_], B](c, summon[CpsMonad[F]])
                     
 
-which is implemented in cps runtime with signature
+which is implemented in the cps runtime with the signature
 
 .. code-block:: scala
 
    AsyncShift[List[A]].map[F[_], B](obj: List[A], cpsMonad: CpsMonad[F])(f: A => F[B])
 
 
-|dotty-cps-async|_ includes implementations of shifted methods for most objects of the Scala standard library.
+|dotty-cps-async|_ includes implementations of shifted methods for most objects of the |Scala standard library|_.
 
 So, we can write something like
 
@@ -56,11 +56,11 @@ How to provide shifted functions.
 
 
 Functional interface.
-^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^
 
-Suppose you want to make high-order methods of your class ``C`` be able to accept lambda functions with ``await``. 
+Suppose you want to make high-order methods of your class ``C`` be able to accept lambda functions with |await|_. 
 For that purpose you have to implement the |given AsyncShift[C]|_ type class with a shifted version of your high-order methods.  
-Such a 'shifted' version has an additional type parameter ``F[_]`` and an additional list of arguments, inserted first, containing the original object instance and an appropriate |CpsMonad[F]|_.  
+Such a 'shifted' version has an additional type parameter ``F[_]`` and an additional list of arguments, inserted first, containing the original object instance and an appropriate |CpsMonad[F]|_ instance.  
 
 
 Parameters should be changed in the following way:
@@ -78,6 +78,10 @@ Example:
    def modified[S](f: T => S): TaggedValue[S] =
      TaggedValue(tag, f(x))
 
+ // Below the changed code:
+ // - type `T => S` of argument `f` becomes `T => F[S]`
+ // - `(o, m)` is prepended as the first argument list
+
  class TaggedValueAsyncShift[T] extends AsyncShift[TaggedValue[T]]:
    def modified[F[_], S](o: TaggedValue[T], m: CpsMonad[F])(f: T => F[S]): F[TaggedValue[S]] =
      f(value).map(TaggedValue(tag,_))
@@ -90,7 +94,7 @@ Example:
 Object-oriented interface.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In some cases, we use classes – defined in an object-oriented manner – with private data.  If we wants a class to provide an API for `dotty-cps-async <https://github.com/rssh/dotty-cps-async#dotty-cps-async>`_, then we can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside our class:
+In some cases, we use classes – defined in an object-oriented manner – with private data.  If we wants a class to provide an API for |dotty-cps-async|_, then we can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside our class:
 
 Example:
 
@@ -110,7 +114,7 @@ Example:
      m.map(f(x))(_ => { sendSignal(x); old }) 
 
 
-As we have seen, shifted functions have an additional type parameter: ``F[_]`` and a parameter |CpsMonad[F]|_ (or more specific type, if needed).  Async transformer will substitute the call of ``modify`` into ``modify_async`` during compilation.
+As we have seen, shifted functions have an additional type parameter: ``F[_]`` and a parameter |CpsMonad[F]|_ (or a more specific type, if needed).  Async transformer will substitute the call of ``modify`` into ``modify_async`` during compilation.
    Sometimes, we already have ``F[_]`` as the type parameter of the enclosing class. We can omit those additional parameters in the async variant in such a case.
 
 Note that you should carefully decide whether you need async function support and how to deal with concurrent modifications.  For example, in the code snippet below, different changes will interleave with each other.
@@ -133,11 +137,11 @@ Consider a chain of calls, which accepts async-shifted functions.  One example i
   } yield item  
 
 
-Here usual semantics of ``withFilter`` assume that we iterate over ``urls`` only once.  But if we translate this expression according to the standard rules, we will receive two passes: one pass in async ``withFilter`` and the second in ``flatMap``.
+Here usual semantics of |withFilter|_ assume that we iterate over ``urls`` only once.  But if we translate this expression according to the standard rules, we will receive two passes: one pass in async ``withFilter`` and the second pass in ``flatMap``.
 
-To perform the iteration once, we translate ``withFilter`` not to ``F[WithFilter]`` but to a substituted type ``DelayedWithFilter``, which holds the received predicate and delays actual evaluation upon the call of the next operation in the chain.
+To perform the iteration once, we translate ``withFilter`` not to ``F[WithFilter]`` but to a substituted type |DelayedWithFilter|_, which holds the received predicate and delays actual evaluation upon the call of the next operation in the chain.
 
-The implementation of class ``DelayedWithFilter`` looks like:
+The implementation of class |DelayedWithFilter|_ looks like:
 
 .. code-block:: scala
 
@@ -145,34 +149,29 @@ The implementation of class ``DelayedWithFilter`` looks like:
      c: CA,
      m: CpsMonad[F],
      p: A => F[Boolean],
- ) extends CallChainAsyncSubst[F, WithFilter[A, C], F[WithFilter[A, C]] ]
+ ) extends CallChainAsyncShiftSubst[F, WithFilter[A, C], F[WithFilter[A, C]] ]
  {
    // return eager copy
    def _finishChain: F[WithFilter[A, C]] = //...
 
    def withFilter(q: A => Boolean): DelayedWithFilter[F, A, CX, CA] = //...
-
    def withFilter_async(q: A=> F[Boolean]) = //...
 
    def map[B](f: A => B): F[C[B]] = //...
-
    def map_async[B](f: A => F[B]): F[C[B]] = //...
 
    def flatMap[B](f: A => IterableOnce[B]): F[C[B]] = //...
-
    def flatMap_async[B](f: A => F[IterableOnce[B]]): F[C[B]] = //...
 
    def foreach[U](f: A => U): F[Unit] = //...
-
    def foreach_async[U](f: A => F[U]): F[Unit] = //...
-
  }
 
 
-I.e., in delayed variant, all original methods should or collect operations into the next delayed object or perform an actual batched call.   
-Also, we have the method ``_finishChain``,  which is called when we have no next call in the chain; an example of such a case is ``val x = c.withFilter(p)``.  
+I.e., in the delayed variant, all original methods should collect operations into the next delayed object or perform an actual batched call.   
+Also, we have the method |finishChain|_,  which is called when we have no next call in the chain; an example of such a case is ``val x = c.withFilter(p)``.  
 
-By convention, the substituted type should be derived from ``CallChainAsyncSubst[F, T]``.
+By convention, the substituted type should be derived from trait |CallChainAsyncShiftSubst[F, T, FT]|_.
 
 
 This structure has a nice categorical interpretation. If you are curious about that, read details in :ref:`categorical-interpretation-for-CallChainAsyncSubst`.
@@ -203,9 +202,9 @@ Here, method ``map`` is used for building the streaming interface. We can provid
 
 Also we can see that our channel structure is already build on top of ``F[_]``, so it is not necessary to pass ``F`` to method parameter.
  
-For convenience `dotty-cps-async <https://github.com/rssh/dotty-cps-async#dotty-cps-async>`_ supports both naming variants of ``mapAsync``: camelCase ``mapAsync`` and snake_case ``map_async``.
+For convenience |dotty-cps-async|_ supports both naming variants of ``mapAsync``: camelCase ``mapAsync`` and snake_case ``map_async``.
 
-We propose to use next convention when naming such methods:
+We propose to use the following convention when naming such methods:
 
 - use ``method_async`` when the async method will unlikely be called directly by the programmer and will be used only for substitution in high-order function;
 - use ``methodAsync`` when we expect that developer can use this method directly along with cps substitution.
@@ -214,17 +213,41 @@ We propose to use next convention when naming such methods:
 Async high-order functional interfaces  
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For a case with an asynchronous high-order function interface (i.e. methods which accept functions like ``f:(A => F[B])`` ), the ``async`` macro can automatically transform the asynchronous result to have the same signature, so you can use ``await`` calls inside async lambdas without implementing additional methods or type classes.
+For a case with an asynchronous high-order function interface (i.e. methods which accept functions like ``f:(A => F[B])``), the |async|_ macro can automatically transform the asynchronous result to have the same signature, so you can use |await|_ calls inside async lambdas without implementing additional methods or type classes.
 
 
 .. ###########################################################################
-.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+.. ## Hyperlink definitions with text formatting (e.g. verbatim, bold)
+
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
+
+.. |CallChainAsyncShiftSubst[F, T, FT]| replace:: ``CallChainAsyncShiftSubst[F, T, FT]``
+.. _CallChainAsyncShiftSubst[F, T, FT]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/runtime/CallChainAsyncShiftSubst.scala#L13
 
 .. |CpsMonad[F]| replace:: ``CpsMonad[F]``
-.. _CpsMonad[F]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+.. _CpsMonad[F]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala#L20
+
+.. |finishChain| replace:: ``_finishChain``
+.. _finishChain: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/runtime/IterableAsyncShift.scala#L427
 
 .. |dotty-cps-async| replace:: **dotty-cps-async**
 .. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
 
+.. |DelayedWithFilter| replace:: ``DelayedWithFilter``
+.. _DelayedWithFilter: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/runtime/IterableAsyncShift.scala#L420
+
 .. |given AsyncShift[C]| replace:: ``given AsyncShift[C]``
-.. _given AsyncShift[C]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncShift.scala
+.. _given AsyncShift[C]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/AsyncShift.scala#L11
+
+.. |map| replace:: ``map``
+.. _map: https://www.scala-lang.org/api/current/scala/collection/immutable/List.html#map[B](f:A=%3EB):List[B]
+
+.. |Scala standard library| replace:: **Scala standard library**
+.. _Scala standard library: https://www.scala-lang.org/api/current/
+
+.. |withFilter| replace:: ``withFilter``
+.. _withFilter: https://www.scala-lang.org/api/current/scala/collection/immutable/List.html#withFilter(p:A=%3EBoolean):scala.collection.WithFilter[A,CC]

--- a/docs/Integrations.rst
+++ b/docs/Integrations.rst
@@ -25,6 +25,7 @@ Add dependency |cps-async-connect-cats-effect|_ to your ``build.sbt`` to integra
   libraryDependencies += "org.typelevel" %% "cats-effect" % "3.3.4"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-cats-effect" % "0.9.5"
 
+|Cats Effect|_ GitHub : |typelevel/cats-effect|_, Maven : |org.typelevel»cats-effect|_.
 
 **Note**: Typelevel's project |cats-effect-cps|_ also provides async/await syntax support for |Cats Effect|_.
 
@@ -39,16 +40,20 @@ Add dependency |cps-async-connect-monix|_ to your ``build.sbt`` to integrate |Mo
   libraryDependencies += "io.monix" %% "monix" % "3.4.0"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-monix" % "0.9.5"
 
+|Monix|_ GitHub : |monix/monix|_, Maven : |io.monix|_.
 
 Scalaz IO
 ^^^^^^^^^
 
-Add dependency |cps-async-connect-scalaz|_ to your ``build.sbt`` to integrate |Scalaz IO|_ :
+Add dependency |cps-async-connect-scalaz|_ to your ``build.sbt`` to integrate |Scalaz IO|_:
 
  .. code-block:: scala
 
+  libraryDependencies += "org.scalaz" %% "scalaz-core" % "7.3.6"
+  libraryDependencies += "org.scalaz" %% "scalaz-effect" % "7.3.6"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-scalaz" % "0.9.5"
 
+|Scalaz IO|_ GitHub : |scalaz/scalaz|_, Maven : |org.scalaz|_.
 
 ZIO and ZIO Streams
 ^^^^^^^^^^^^^^^^^^^
@@ -60,17 +65,19 @@ Add dependency |cps-async-connect-zio|_ to your ``build.sbt`` to integrate |ZIO|
   libraryDependencies += "dev.zio" %% "zio" % "2.0.0-RC1"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-zio" % "0.9.5"
 
+|ZIO|_ GitHub: |zio/zio|_, Maven : |dev.zio|_.
 
-Akka Streams
-^^^^^^^^^^^^
+Akka Stream
+^^^^^^^^^^^
 
-Add dependency |cps-async-connect-akka-stream|_ to your ``build.sbt`` to integrate Lightbend's |Akka Streams|_ :
+Add dependency |cps-async-connect-akka-stream|_ to your ``build.sbt`` to integrate Lightbend's |Akka Stream|_ :
 
  .. code-block:: scala
 
   libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.18"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-akka-stream" % "0.9.5"
 
+|Akka Stream|_ GitHub : |akka/akka|_, Maven : |com.typesafe.akka»akka-stream|_.
 
 FS2 Stream
 ^^^^^^^^^^
@@ -83,13 +90,14 @@ Add dependency |cps-async-connect-fs2|_ to your ``build.sbt`` to integrate Typel
   libraryDependencies += "co.fs2" %% "fs2-io" % "3.2.0"
   libraryDependencies += "com.github.rssh" %%% "cps-async-connect-fs2" % "0.9.5"
 
+|FS2|_ GitHub : |typelevel/fs2|_, Maven : |co.fs2|_.
 
 typelevel/cats-effect-cps
 -------------------------
 
 GitHub project: https://github.com/typelevel/cats-effect-cps
 
-|cats-effect-cps|_ is an experimental library to support uniform async/await syntax for |Cats Effect|_ in Scala 2 and Scala 3, integrated with |Typelevel ecosystem|_.
+|cats-effect-cps|_ is an experimental library to support uniform async/await syntax for |Cats Effect|_ in Scala 2 and Scala 3, integrated with the |Typelevel ecosystem|_.
 
 
 Call for additions:
@@ -101,14 +109,23 @@ If you have implemented |CpsMonad|_ support for some effect stack and want to me
 .. ###########################################################################
 .. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
-.. |Akka Streams| replace:: **Akka Streams**
-.. _Akka Streams: <https://doc.akka.io/docs/akka/current/stream/
+.. |Akka Stream| replace:: **Akka Stream**
+.. _Akka Stream: <https://doc.akka.io/docs/akka/current/stream/
+
+.. |akka/akka| replace:: ``akka/akka``
+.. _akka/akka: https://github.com/akka/akka
 
 .. |Cats Effect| replace:: **Cats Effect**
 .. _Cats Effect: https://typelevel.org/cats-effect/
 
 .. |cats-effect-cps| replace:: ``cats-effect-cps``
 .. _cats-effect-cps: https://github.com/typelevel/cats-effect-cps
+
+.. |co.fs2| replace:: ``co.fs2``
+.. _co.fs2: https://mvnrepository.com/artifact/co.fs2
+
+.. |com.typesafe.akka»akka-stream| replace:: ``com.typesafe.akka»akka-stream``
+.. _com.typesafe.akka»akka-stream : https://mvnrepository.com/artifact/com.typesafe.akka/akka-stream
 
 .. |CompletableFuture| replace:: ``CompletableFuture``
 .. _CompletableFuture: https://github.com/rssh/dotty-cps-async/blob/master/jvm/src/main/scala/cps/monads/CompletableFutureCpsMonad.scala
@@ -132,13 +149,19 @@ If you have implemented |CpsMonad|_ support for some effect stack and want to me
 .. _cps-async-connect-zio: https://github.com/rssh/cps-async-connect#zio
 
 .. |CpsMonad| replace:: ``CpsMonad``
-.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala#L20
+
+.. |dev.zio| replace:: ``dev.zio``
+.. _dev.zio: https://mvnrepository.com/artifact/dev.zio
 
 .. |dotty-cps-async| replace:: **dotty-cps-async**
 .. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
 
 .. |FS2| replace:: **FS2**
 .. _FS2: https://fs2.io/
+
+.. |io.monix| replace:: ``io.monix``
+.. _io.monix: https://mvnrepository.com/artifact/io.monix
 
 .. |FutureAsyncMonad| replace:: ``FutureAsyncMonad``
 .. _FutureAsyncMonad: https://https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/monads/FutureAsyncMonad.scala
@@ -152,11 +175,31 @@ If you have implemented |CpsMonad|_ support for some effect stack and want to me
 .. |Monix| replace:: **Monix**
 .. _Monix: https://monix.io/
 
+.. |monix/monix| replace:: ``monix/monix``
+.. _monix/monix: https://github.com/monix/monix
+
+.. |org.scalaz| replace:: ``org.scalaz``
+.. _org.scalaz: https://mvnrepository.com/artifact/org.scalaz
+
+.. |org.typelevel»cats-effect| replace:: ``org.typelevel»cats-effect`` 
+.. _org.typelevel»cats-effect : https://mvnrepository.com/artifact/org.typelevel/cats-effect
+
 .. |Scalaz IO| replace:: **Scalaz IO**
 .. _Scalaz IO: https://scalaz.github.io/
+
+.. |scalaz/scalaz| replace:: ``scalaz/scalaz``
+.. _scalaz/scalaz: https://github.com/scalaz/scalaz
 
 .. |Typelevel ecosystem| replace:: **Typelevel ecosystem**
 .. _Typelevel ecosystem: https://typelevel.org/cats/typelevelEcosystem.html
 
+.. |typelevel/cats-effect| replace:: ``typelevel/cats-effect`` 
+.. _typelevel/cats-effect : https://github.com/typelevel/cats-effect
+
+.. |typelevel/fs2| replace:: ``typelevel/fs2``
+.. _typelevel/fs2: https://github.com/typelevel/fs2
 .. |ZIO| replace:: **ZIO**
 .. _ZIO: https://zio.dev/
+
+.. |zio/zio| replace:: ``zio/zio``
+.. _zio/zio: https://github.com/zio/zio

--- a/docs/MonadContexts.rst
+++ b/docs/MonadContexts.rst
@@ -2,8 +2,8 @@ Monad Context
 =============
 
 Monad context is a way to provide an additional API, which is available only inside some monad 
-(i.e., inside appropriative ``await`` block).   
-In the introduction chapter, we have shown a simplified representation of the ``async`` signature:
+(i.e., inside appropriative |await|_ block).   
+In the introduction chapter, we have shown a simplified representation of the |async|_ signature:
 
 .. code-block:: scala
 
@@ -27,13 +27,13 @@ The complete definition looks like:
   }
 
 
-Here we split an application into two parts, to have one type parameter in ``await``; this will become possible ``async[F]`` syntax.
+Here we split an application into two parts, to have one type parameter in |await|_; this becomes possible with the ``async[F]`` syntax.
 Take a look at the argument of the ``InferAsyncArg.apply`` method: ``expr: C ?=> T``.   
 This is a context function. The context parameter ``C`` is extracted from the monad definition. 
-Inside ``expr`` the Scala compiler makes an implicit instance of ``C`` available, which we can use to provide internal monad API. 
+Inside ``expr`` the Scala 3 compiler makes an implicit instance of ``C`` available, which we can use to provide an internal monad API. 
 
 Using a context parameter makes our monad a bit more complex than traditional Haskell-like monad constructions but allows us to represent important industry cases, like structured concurrency.   
-Jokingly, we can say that our monad is close to the original Leibnic definition from Monadology, where each monad has unique qualities, not accessible from outside.
+Jokingly, we can say that our monad is close to the original Leibnic definition of Monadology, where each monad has unique qualities, not accessible from outside.
 
 The monad context is defined as a type inside |CpsMonad|_ :
 
@@ -47,7 +47,7 @@ The monad context is defined as a type inside |CpsMonad|_ :
     }
 
 
-|CpsMonadContext|_ provides functionality to adopt awaiting another monadic expression into the current context.
+|CpsMonadContext|_ provides the functionality to adopt awaiting another monadic expression into the current context.
       
 .. code-block:: scala
 
@@ -61,36 +61,39 @@ The monad context is defined as a type inside |CpsMonad|_ :
     }
 
 
-For a practical example, let's consider adding a timeout to the plain scala future.  
+As a practical example, let's consider adding a timeout to the plain Scala future.  
 I.e., let's think about how to build the monad ``FutureWithTimeout``, which will complete within a timeout or fire a 
-|TimeoutException|_. It's more or less clear how to combine a small ``Future``-s with timeouts into one 
-(at this point, we can rename timeouts to deadlines), but what to do with the situation when control flow 
-is waiting for completing an external |Future|_ in ``await``? The answer is the usage of monad context:  
+|TimeoutException|_. It's more or less clear how to combine a small |Future|_ with timeouts into one 
+(at this point, we can rename timeouts to deadlines), but what should we do when the control flow 
+is waiting for completing an external |Future|_ in |await|_? The answer is the usage of a monad context:  
 ``adoptAwait`` can generate a promise, which will be filled in case of finishing ``f`` or elapsing timeout.  
 
-
-To look at the implementation of such approach see a test example, e.g. |TestFutureWithDeadline.scala|_.
+See example |TestFutureWithDeadline.scala|_ for the implementation of such an approach.
 
 Note that this is one variant of the code organization approach.  Alternatively, we can signal to ``f``, 
 if we know that we are exclusively own ``f`` evaluation. This can be an approach for lazy effect.  
-The design choice for possible solutions is quite big.
+The design choice for possible solutions is quite large.
 
-For monad writers: as a general design rule, use monad context when you want to provide access to some API, 
-which should be visible only inside a monad (i.e., inside ``await``).  For trivial cases, when you don't need 
-context API, you can mix |CpsMonadInstanceContext|_ into your implementation of CpsMonad.  
+For monad writers: as a general design rule, use monad context when you want to provide access to some API, which should be visible only inside a monad (i.e. inside |await|_).  For trivial cases, when you don't need a context API, you can mix |CpsMonadInstanceContext|_ into your implementation of trait |CpsMonad|_.  
 For more advanced cases, we advise using the |CpsContextMonad|_ trait.
 
-Also, you can notice the compatibility of this context with monadic-reflection, based on Flinsky encoding, where ``async`` become ``reify`` and ``await`` accordingly ``reflect``. 
+Also, you can notice the compatibility of this context with |monadic-reflection|_, based on Flinsky encoding, where |async|_ becomes |reify|_ and |await|_ accordingly |reflect|_. 
 
 
 .. ###########################################################################
 .. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
+
 .. |CpsMonad| replace:: ``CpsMonad``
-.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala
+.. _CpsMonad: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonad.scala#L20
 
 .. |CpsMonadContext| replace:: ``CpsMonadContext``
-.. _CpsMonadContext: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadContext.scala
+.. _CpsMonadContext: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadContext.scala#L11
 
 .. |CpsContextMonad| replace:: ``CpsContextMonad``
 .. _CpsContextMonad: https://github.com/rssh/dotty-cps-async/blob/a6f2bfdf83f4ffb9985b455c57e867e3e9b8c9da/shared/src/main/scala/cps/CpsMonadContext.scala#L47
@@ -100,6 +103,15 @@ Also, you can notice the compatibility of this context with monadic-reflection, 
 
 .. |Future| replace:: ``Future``
 .. _Future: https://www.scala-lang.org/api/current/scala/concurrent/Future.html
+
+.. |monadic-reflection| replace:: **monadic-reflection**
+.. _monadic-reflection: https://github.com/lampepfl/monadic-reflection
+
+.. |reflect| replace:: ``reflect``
+.. _reflect: https://github.com/lampepfl/monadic-reflection/blob/main/core/src/main/scala/monadic/Monadic.scala#L26
+
+.. |reify| replace:: ``reify``
+.. _reify: https://github.com/lampepfl/monadic-reflection/blob/main/core/src/main/scala/monadic/Monadic.scala#L31
 
 .. |TimeoutException| replace:: ``TimeoutException``
 .. _TimeoutException: https://www.scala-lang.org/api/current/scala/concurrent/index.html#TimeoutException=java.util.concurrent.TimeoutException

--- a/docs/MonadsInteroperability.rst
+++ b/docs/MonadsInteroperability.rst
@@ -1,18 +1,18 @@
 Monads interoperability.
 ========================
 
-Monads in ``async`` and ``await`` can be different: ``await[F]`` can be applied inside ``async[G]``  when exists 
+Monads in |async|_ and |await|_ can be different: ``await[F]`` can be applied inside ``async[G]``  when exists 
 |CpsMonadConversion[F, G]|_.
 
 ``Future`` Examples
 -------------------
 
-``async[F]{ await[Future]( /*..*/ ) }``
-.......................................
+``async[F] { await[Future]( /*..*/ ) }``
+........................................
 
 We first describe how to invoke ``await[Future]`` inside a ``async[F]`` block.
 
-Here is an example of implementation of ``Conversion`` from ``Future`` to any async monad ``G[_]`` :
+Here is an example of implementation of ``Conversion`` from |Future|_ to any async monad ``G[_]`` :
 
 
 .. code-block:: scala
@@ -40,12 +40,12 @@ Here 'async monad' for ``G[_]`` means it is possible to receive ``G[T]`` from a 
  }
 
 
-After making this definition available, we can await |Future|_ into any async monad:
+After making this definition available, we can await |Future|_ inside any async monad:
 
 
 .. code-block:: scala
 
- def fun(x:Int):Future[Int] =
+ def fun(x: Int): Future[Int] =
    Future successful (x+1)
 
  val c = async[ComputationBound] {
@@ -54,8 +54,8 @@ After making this definition available, we can await |Future|_ into any async mo
  }
 
 
-``async[Future]{ await[F]( /*..*/ ) }``
-.......................................
+``async[Future] { await[F]( /*..*/ ) }``
+........................................
 
 And how about inserting ``await[F]`` into a ``async[Future]`` block ?
 
@@ -84,11 +84,9 @@ Of course, it is possible to create other conversions between your monads, based
 js.Promise
 -----------
 
-Not only monads can be subject to await. For example, it is impossible to attach monad structure to ``js.Promise`` in scalajs, 
-because map operation is unimplementable: all ``Promise`` operations flatten their arguments.  But we can await ``Promise`` from Scala
-``async[Future]`` blocks, because ``CpsMonadConversion[Future, Promise]`` is defined.
+Not only monads can be subject to await. For example, it is impossible to attach monad structure to ``js.Promise`` in |Scala.js|_, because the map operation is unimplementable: all |Promise|_ operations flatten their arguments.  But we can await |Promise|_ from Scala ``async[Future]`` blocks, because |CpsMonadConversion[Future, Promise]|_ is defined.
 
-Also, for fluent implementation of JS facades, |dotty-cps-async|_ provides the |JSFuture|_ trait, which has monadic operations in Scala and visible from JavaScript as ``Promise``.  
+Also, for fluent implementation of JS facades, |dotty-cps-async|_ provides the |JSFuture|_ trait, which has monadic operations in Scala and visible from JavaScript as |Promise|_.  
 i.e. with the following definitions:
 
 .. code-block:: scala
@@ -111,8 +109,20 @@ i.e. with the following definitions:
 .. ###########################################################################
 .. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
 
+.. |async| replace:: ``async``
+.. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30
+
+.. |await| replace:: ``await``
+.. _await: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L19
+
+.. |ComputationBound| replace:: ``ComputationBound``
+.. _ComputationBound: https://github.com/rssh/dotty-cps-async/blob/master/jvm/src/test/scala/cps/ComputationBound.scala
+
 .. |CpsMonadConversion[F, G]| replace:: ``CpsMonadConversion[F, G]``
 .. _CpsMonadConversion[F, G]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadConversion.scala
+
+.. |CpsMonadConversion[Future, Promise]| replace:: ``CpsMonadConversion[Future, Promise]``
+.. _CpsMonadConversion[Future, Promise]: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsMonadConversion.scala
 
 .. |dotty-cps-async| replace:: **dotty-cps-async**
 .. _dotty-cps-async: https://github.com/rssh/dotty-cps-async#dotty-cps-async
@@ -124,7 +134,10 @@ i.e. with the following definitions:
 .. _FutureAsyncMonad.scala: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/monads/FutureAsyncMonad.scala
 
 .. |JSFuture| replace:: ``JSFuture``
-.. _JSFuture: https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/jsfuture/JSFuture.scala
+.. _JSFuture: https://github.com/rssh/dotty-cps-async/blob/master/js/src/main/scala/cps/monads/jsfuture/JSFuture.scala#L53
 
 .. |Promise| replace:: ``Promise``
-.. _Promise: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#description
+.. _Promise: https://www.scala-js.org/api/scalajs-library/latest/scala/scalajs/js/Promise.html
+
+.. |Scala.js| replace:: **Scala.js**
+.. _Scala.js: https://www.scala-js.org/

--- a/docs/References.md
+++ b/docs/References.md
@@ -5,24 +5,24 @@
 
 Can we free concurrent programming from the monadic style:
 
-* ScalaR:  <https://www.youtube.com/watch?v=ImlUuTQUeaQ>  (Jun 2020)
-* ScalaUA: <https://www.youtube.com/watch?v=w-noRPLxYoA>  (Apr. 2020)
+* ScalaR:  <https://www.youtube.com/watch?v=ImlUuTQUeaQ>  (June 2020)
+* ScalaUA: <https://www.youtube.com/watch?v=w-noRPLxYoA>  (April 2020)
     * slides: <https://www.slideshare.net/rssh1/can-concurrent-functional-programming-be-liberated-from-monadic-style>
 
-## Related work in Scala2
+## Related work in Scala 2
 
 - Scala-continuations.  paper:  <https://infoscience.epfl.ch/record/149136/files/icfp113-rompf.pdf>
 - Scala-async:   <https://github.com/scala/scala-async>
 - Storm-enroute coroutines:  <https://drops.dagstuhl.de/opus/volltexte/2018/9208/pdf/LIPIcs-ECOOP-2018-3.pdf>
 - Thoughtworks DSL.scala:  <https://github.com/ThoughtWorksInc/Dsl.scala>
 - Monadless.io: <http://monadless.io/>
-- Effectfull: <https://github.com/pelotom/effectful>
+- Effectful: <https://github.com/pelotom/effectful>
 - Scala-gopher tech report: <https://arxiv.org/abs/1611.00602>
    
-## Related work in Scala3
+## Related work in Scala 3
  
  - Monadic-reflection <https://github.com/lampepfl/monadic-reflection>  (require Project Loom enabled JVM)
--  Thoughtworks DSL.scala recently ported to Scala3:  <https://github.com/ThoughtWorksInc/Dsl.scala> 
+-  Thoughtworks DSL.scala recently ported to Scala 3:  <https://github.com/ThoughtWorksInc/Dsl.scala> 
 
 ## Related work in other languages
 
@@ -38,7 +38,7 @@ Can we free concurrent programming from the monadic style:
 - Python: PEP-0492  <https://www.python.org/dev/peps/pep-0492/>
 - JavaScript:  <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/async_function>
 - Nim: macro module <https://nim-lang.org/docs/asyncdispatch.html>
-- Dart:
+- [Dart](https://dart.dev/codelabs/async-await):
 	- Guide: <https://dart.dev/guides/language/language-tour#asynchrony-support>
 	- Formal specs: <https://spec.dart.dev/DartLangSpecDraft.pdf>  (async intro on page 18)
         - Spicing Up Dart with Side Effects (streams extension) <https://dl.acm.org/doi/pdf/10.1145/2742694.2747873>
@@ -61,13 +61,12 @@ Can we free concurrent programming from the monadic style:
 - Koka:
 	- Paper: "Structured Asynchrony with Algebraic Effects" <https://www.microsoft.com/en-us/research/wp-content/uploads/2017/05/asynceffects-msr-tr-2017-21.pdf>
 - OCaml:
-        - Paper: "Concurrent System Programming with Effect Handlers": <https://kcsrk.info/papers/system_effects_feb_18.pdf>
-        - efects tutorial <https://github.com/ocamllabs/ocaml-effects-tutorial>
-        - Paper: Retrofitting Effect Handlers onto OCaml. <https://arxiv.org/abs/2104.00250>
+    - Paper: "Concurrent System Programming with Effect Handlers": <https://kcsrk.info/papers/system_effects_feb_18.pdf>
+    - Effects tutorial <https://github.com/ocamllabs/ocaml-effects-tutorial> (CUFP'17)
+    - Paper: Retrofitting Effect Handlers onto OCaml. <https://arxiv.org/abs/2104.00250>
 
 
 ## Monadic Computations in Functional Programming (unrelated to PO Syntax, most examples are Haskell).
 
 
-   - Extenging monads via pattern matching (joinads for haskell):  http://tomasp.net/academic/papers/docase/docase.pdf
-
+   - Extending monads via pattern matching (joinads for haskell): <http://tomasp.net/academic/papers/docase/docase.pdf>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,12 +14,14 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
+from datetime import datetime
+currentYear = datetime.now().year
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'dotty-cps-async'
-copyright = '2020-2021, Ruslan Shevchenko'
+copyright = '2020-{}, Ruslan Shevchenko'.format(currentYear)
 author = 'Ruslan Shevchenko'
 
 # The full version, including alpha/beta/rc tags

--- a/docs/random-notes/CpsAsyncOverview.md
+++ b/docs/random-notes/CpsAsyncOverview.md
@@ -13,7 +13,7 @@ Let’s look an example:
 
 Direct-style:
 
-```
+```scala
 val  connection = openConnection()
 val  command = connection.readCommand()
 val  result = engine.evaluateCommand(command)
@@ -70,7 +70,7 @@ I.e. operations with concurrent API  often return ```M[F]```, and you can work w
  * await:  ```M[X] => X```
  * async:  ```X => M[X]```
 
-Async apply monad CPS to it’s argument.  Note, that the transformation of ```await(expr)``` will be ```expr```.  (i.e. all occurrences of await will be erased).  And we can use direct style instead monadic compositions, leaving work of aligning compositions to a computer.  This is exactly wat dotty-cps-async do.
+Async apply monad CPS to it’s argument.  Note, that the transformation of ```await(expr)``` will be ```expr```.  (i.e. all occurrences of await will be erased).  And we can use direct style instead monadic compositions, leaving work of aligning compositions to a computer.  This is exactly wat [dotty-cps-async](https://github.com/rssh/dotty-cps-async#dotty-cps-async) do.
 
 
 ### Optimizations.
@@ -82,8 +82,8 @@ We want to keep sequential parts to be left sequential, so the number of flatMap
 
 ### Implementation notes.
 
-   * We don't do ANF transform preprocessing, but transform code as is, by providing implementation along with some micoroptimization, as the same way, as human will transform those expressions 'by hands'.
-   * For chunks of code, which can be deconstructed with help of dotty 'quote' expressions, we use representation of block as 'CpsExpr'. Other expressions, deconstructed as tasty trees and represented as 'CpsTree'.
+   * We don't do ANF transform preprocessing, but transform code as is, by providing implementation along with some micro-optimization, as the same way, as human will transform those expressions 'by hands'.
+   * For chunks of code, which can be deconstructed with help of dotty 'quote' expressions, we use representation of block as 'CpsExpr'. Other expressions, deconstructed as tasty trees and represented as ```CpsTree```.
  
 
 


### PR DESCRIPTION
Follow up of PR #52.

Brings further updates to .rst files in [`docs/`](https://github.com/rssh/dotty-cps-async/tree/master/docs)
- corrected more typos
- fixed indentation in `asyncStream` code example
- added/fixed more hyperlinks
- renamed `CallChainAsyncSubst` to `CallChainAsyncShiftSubst`
- updated copyright date in file `conf.py` (automatic update)

