### PR TITLE
Rewrote some phrases and fixed some typos  in docs

### DIFF
--- a/docs/AsyncStreams.rst
+++ b/docs/AsyncStreams.rst
@@ -32,7 +32,7 @@ Example:
 
 I recommend you try |AsyncList|_.
 
-Here |AsyncList|_ is a minimal implementation of async stream supplied with |dotty-cps-async|_.
+Here, |AsyncList|_ is a minimal implementation of async stream supplied with |dotty-cps-async|_.
 There exist integration modules for well-known async streaming libraries (see section :ref:`Integrations`).
 
 The input of |asyncStream|_ is a code block which should be a lambda expression that accepts an emitter argument; i.e., the simplified definition looks as follows :
@@ -55,7 +55,7 @@ Writing generator adapters for custom streams
 To allow generator syntax for your stream, you need to implement trait
  |CpsAsyncEmitAbsorber[R]|_ where |eval|_ accepts a cps-transformed function and outputs the result stream.
  
-|dotty-cps-async|_ provides a platform-specific trait |BaseUnfoldCpsAsyncEmitAbsorber|_ which can simplicify generator implementations for streams which has something like ``unfoldAsync[S, E](s: S)(f: S => F[Option[(S, E)]]): R``.
+|dotty-cps-async|_ provides a platform-specific trait |BaseUnfoldCpsAsyncEmitAbsorber|_ which can simplify generator implementations for streams having something like ``unfoldAsync[S, E](s: S)(f: S => F[Option[(S, E)]]): R``.
 
 For example, look at the implementation of |CpsAsyncEmitAbsorber[R]|_ for |Akka Streams|_ source:
 

--- a/docs/AutomaticColoring.rst
+++ b/docs/AutomaticColoring.rst
@@ -102,7 +102,7 @@ Custom value discard
 
 .. index:: customValueDiscard
 
-During the writing of asynchronous code, typical developers’ mistakes are to forget to handle something connected with discarded values, like error processing or awaiting.  
+During the writing of asynchronous code,  a typical developers’ mistake is to forget to handle something connected with discarded values, like error processing or awaiting.
 
 ``cps.customValueDiscard`` limits the value discarding in the non-final expression in the block.  When enabled, value discarding is allowed only for those types ``T``, for which it exists an implementation of a special |ValueDiscard[T]|_.
 
@@ -140,7 +140,7 @@ Here the developer forgot to wrap ``dryRun`` into |await|_.  But ``customValueDi
 
 .. index:: warnValueDiscard
 
-If you want to see warning instead error, you can import `warnValueDiscard` feature:
+If you want to see a warning instead of an error, you can import `warnValueDiscard` feature:
 
 .. code-block:: scala
 
@@ -148,7 +148,7 @@ If you want to see warning instead error, you can import `warnValueDiscard` feat
  import cps.warnValueDiscard
 
 
-Note that custom value discarding is automatically enabled for effect monads to prevent situations where discarding values drop branches in the computation flow. Let's look again at the code:
+Note that custom value discarding is automatically enabled for effect monads, to prevent situations where discarding values drop branches in the computation flow. Let's look again at the code:
 
 .. code-block:: scala
 

--- a/docs/BasicUsage.rst
+++ b/docs/BasicUsage.rst
@@ -59,7 +59,7 @@ Inside the async block, we can use the |await|_ pseudo-function.
  .. index:: CpsMonad
  .. index:: CpsTryMonad
 
-In the above code type ``MyMonad`` must implement one of the two type classes |CpsMonad|_ or |CpsTryMonad|_ (which supports try/catch).
+In the above code, the type ``MyMonad`` must implement one of the two type classes |CpsMonad|_ or |CpsTryMonad|_ (which supports try/catch).
 
 The minimal complete snippet looks as follows:
 
@@ -101,7 +101,7 @@ This minimal example is for |Future|_ monad and depends on library |dotty-cps-as
 **Note**: The :ref:`Integrations` section lists further library dependencies needed for integration with well-known monadic frameworks such as |Cats Effect|_, |Monix|_, |ScalaZ IO|_ or |ZIO|_ and streaming frameworks like |Akka Streams|_ and |fs2|_. 
 
 
-Also a monad can be abstracted out as in the following example:
+A monad  can also be abstracted out as in the following example:
 
 
  .. code-block:: scala
@@ -159,16 +159,16 @@ The |async|_ macro will transform the code block into something like
 
   </details>
 
-As transformation technique we use optimized monadic transform, the number of monadic brackets is the 
+Since we use optimized monadic transform as the transformation technique, the number of monadic brackets will be  the
 same as the number of |await|_ s in the source code.  
 You can read the :ref:`notes about implementation details <random-notes>`.
 
 Alternative names
 -----------------
 
-`async/await` names appropriative for Future-s and effect monads. There are other monads for which direct style can be helpful 
-in such applications as probabilistic programming or navigation over search space or collections and many other.  
-We define alternative names for macroses: `reify/reflect`, which can be more appropriative in the general case:
+`async/await` names is appropriate for Future-s and effect monads. There are other monads where a  direct style can be helpful
+in applications such as probabilistic programming, navigation over search space, collections, and many other.
+We define alternative names for macros: `reify/reflect`, which can be more appropriate in the general case:
 
 
 .. code-block:: scala
@@ -192,7 +192,7 @@ We define alternative names for macroses: `reify/reflect`, which can be more app
 
 
 
-Yet one pair of names 'lift/unlift' used in monadless library by Flavio W. Brasill and can be enabled by importing `cps.syntax.monadless.*`.
+Yet one pair of names 'lift/unlift', used for example in the |monadless|_ library by Flavio W. Brasill,  can be enabled by importing `cps.syntax.monadless.*`.
 
 
 .. code-block:: scala
@@ -281,6 +281,8 @@ Yet one pair of names 'lift/unlift' used in monadless library by Flavio W. Brasi
 .. |Monix| replace:: **Monix**
 .. _Monix: https://monix.io/
 
+.. |monadless| replace:: ``monadless``
+.. _monadless: https://github.com/monadless/monadless
 .. |Scala 3| replace:: **Scala 3**
 .. _Scala 3: https://dotty.epfl.ch/
 

--- a/docs/Features.rst
+++ b/docs/Features.rst
@@ -4,7 +4,7 @@ Additional Features
 Short syntax for ``await``
 --------------------------
 
-It can be helpful when monad or environment does not support automatic coloring, but the default |await|_ syntax is too heavy.  For this case, we define the |unary_!|_ operator for use instead of |await|_. 
+It can be helpful when the monad or environment does not support automatic coloring, but the default |await|_ syntax is too heavy.  In this case, we define the |unary_!|_ operator to use instead of |await|_.
 
 Example:
 

--- a/docs/HighOrderFunctions.rst
+++ b/docs/HighOrderFunctions.rst
@@ -3,7 +3,7 @@ High-order functions.
 
 |dotty-cps-async|_ supports the automatic transformation of high-order functions, where the lambda expression argument contains |await|_.  
 
-For example, assume an HTTP client provides the following interface to fetch some data from a list of remote servers.
+For example, assume an HTTP client providing the following interface to fetch some data from a list of remote servers.
 
 .. code-block:: scala
 
@@ -11,7 +11,7 @@ For example, assume an HTTP client provides the following interface to fetch som
    def fetchData(url: String): Future[String] 
 
 
-Then we can fetch data from all servers just by using |await|_ in the |map|_ argument:
+Then, we can fetch data from all servers just by using |await|_ in the |map|_ argument:
 
 .. code-block:: scala
 
@@ -27,7 +27,7 @@ If we want all requests to run in parallel, we can start them in one map and, wh
        urls.map( httpClient.fetchData(_) ).map(await(_))
 
 
-For handling awaits inside high-order functions, dotty-cps-async use different strategies in dependency of execution runtime capabilities.
+For handling awaits inside high-order functions, dotty-cps-async uses different strategies in dependency of execution runtime capabilities.
 
 Async shift substitution.
 -------------------------
@@ -62,7 +62,7 @@ Loom-based runtime await.
 
 JDK-19 includes a set of interfaces (project Loom) that allows execution of code in virtual threads, 
 where runtime blocking wait is not blocking from OS view:  real thread can execute tasks from other virtual threads during the wait.   
-In this case, we don't need to substitute a high-order function but transform instead change the function argument to the original form 
+In this case, we don't need to substitute a high-order function but change instead the function argument to the original form,
 if our monad implements the `CpsRuntimeAwait <https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/CpsRuntimeAwait.scala>`_  typeclass.
 
 This experimental feature should be enabled by declaring the implicit value of cps.macros.flags.UsingLoomAwait
@@ -77,7 +77,7 @@ Functional interface.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Suppose you want to make high-order methods of your class ``C`` be able to accept lambda functions with |await|_. 
-For that purpose you have to implement the |given AsyncShift[C]|_ type class with a shifted version of your high-order methods.  
+For that purpose, you have to implement the |given AsyncShift[C]|_ type class with a shifted version of your high-order methods.
 Such a 'shifted' version has an additional type parameter ``F[_]`` and an additional list of arguments, inserted first, containing the original object instance and an appropriate |CpsMonad[F]|_ instance.  
 
 
@@ -112,7 +112,7 @@ Example:
 Object-oriented interface.
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In some cases, we use classes – defined in an object-oriented manner – with private data.  If we wants a class to provide an API for |dotty-cps-async|_, then we can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside our class:
+In some cases, we use classes – defined in an object-oriented manner – with private data.  If we want a class to provide an API for |dotty-cps-async|_, then we can do this without breaking encapsulation. What is needed - to implement an async-shifted version of the function inside our class:
 
 Example:
 
@@ -155,7 +155,7 @@ Consider a chain of calls, which accepts async-shifted functions.  One example i
   } yield item  
 
 
-Here usual semantics of |withFilter|_ assume that we iterate over ``urls`` only once.  But if we translate this expression according to the standard rules, we will receive two passes: one pass in async ``withFilter`` and the second pass in ``flatMap``.
+Here, the usual semantics of |withFilter|_ assume that we iterate over ``urls`` only once.  But if we translate this expression according to the standard rules, we will receive two passes: one pass in async ``withFilter`` and the second pass in ``flatMap``.
 
 To perform the iteration once, we translate ``withFilter`` not to ``F[WithFilter]`` but to a substituted type |DelayedWithFilter|_, which holds the received predicate and delays actual evaluation upon the call of the next operation in the chain.
 
@@ -187,7 +187,7 @@ The implementation of class |DelayedWithFilter|_ looks like:
 
 
 I.e., in the delayed variant, all original methods should collect operations into the next delayed object or perform an actual batched call.   
-Also, we have the method |finishChain|_,  which is called when we have no next call in the chain; an example of such a case is ``val x = c.withFilter(p)``.  
+We also  have the method |finishChain|_,  which is called when we have no next call in the chain; an example of such a case is ``val x = c.withFilter(p)``.
 
 By convention, the substituted type should be derived from trait |CallChainAsyncShiftSubst[F, T, FT]|_.
 
@@ -218,14 +218,14 @@ Here, method ``map`` is used for building the streaming interface. We can provid
    def mapAsync(f: A => F[B]): ReadChannel[F, B]
 
 
-Also we can see that our channel structure is already build on top of ``F[_]``, so it is not necessary to pass ``F`` to method parameter.
+Also, we can see that our channel structure is already build on top of ``F[_]``, so it is not necessary to pass ``F`` to method parameter.
  
-For convenience |dotty-cps-async|_ supports both naming variants of ``mapAsync``: camelCase ``mapAsync`` and snake_case ``map_async``.
+For convenience, |dotty-cps-async|_ supports both naming variants of ``mapAsync``: camelCase ``mapAsync`` and snake_case ``map_async``.
 
 We propose to use the following convention when naming such methods:
 
 - use ``method_async`` when the async method will unlikely be called directly by the programmer and will be used only for substitution in high-order function;
-- use ``methodAsync`` when we expect that developer can use this method directly along with cps substitution.
+- use ``methodAsync`` when we expect that the developer can use this method directly along with cps substitution.
 
 
 Async high-order functional interfaces  

--- a/docs/MonadContexts.rst
+++ b/docs/MonadContexts.rst
@@ -32,16 +32,16 @@ Take a look at the argument of the ``InferAsyncArg.apply`` method: ``expr: C ?=>
 This is a context function. The context parameter ``C`` is extracted from the monad definition. 
 Inside ``expr`` the Scala 3 compiler makes an implicit instance of ``C`` available, which we can use to provide an internal monad API. 
 
-The complete await signature lools like:
+The complete await signature looks like:
 
 .. code-block:: scala
 
-  def await[F[_], T, G[_]](using CpsAwaitabe[F], CpsMonadContext[G])(expr: T) => F[T]
+  def await[F[_], T, G[_]](using CpsAwaitable[F], CpsMonadContext[G])(expr: T) => F[T]
 
 where `F` is a type of awaited wrapper and `G` monad in enclosing |async|_ block.
 
 
-Using a context parameter makes our monad a bit more complex than traditional Haskell-like monad constructions but allows us to represent important industry cases, like |structured concurrency|_.   
+Using a context parameter makes our monad a bit more complex than traditional Haskell-like monad constructions, but allows us to represent important industry cases, like |structured concurrency|_.
 Jokingly, we can say that our monad is close to the original Leibnic definition of monad in his work |Monadology|_, where each monad has unique qualities, not accessible from outside.
 
 The monad context is defined as a type inside |CpsMonad|_ :
@@ -81,7 +81,7 @@ is waiting for completing an external |Future|_ in |await|_? The answer is the u
 See example |TestFutureWithDeadline.scala|_ for the implementation of such an approach.
 
 Note that this is one variant of the code organization approach.  Alternatively, we can signal to ``f``, 
-if we know that we are exclusively own ``f`` evaluation. This can be an approach for lazy effect.  
+if we know that we  exclusively own ``f`` evaluation. This can be an approach for lazy effect.
 The design choice for possible solutions is quite large.
 
 For monad writers: as a general design rule, use monad context when you want to provide access to some API, which should be visible only inside a monad (i.e. inside |await|_).  For trivial cases, when you don't need a context API, you can mix |CpsMonadInstanceContext|_ into your implementation of trait |CpsMonad|_.  
@@ -91,7 +91,7 @@ Also, you can notice the compatibility of this context with |monadic-reflection|
 
 
 .. ###########################################################################
-.. ## Hyperlink definitions with text formating (e.g. verbatim, bold)
+.. ## Hyperlink definitions with text formatting (e.g. verbatim, bold)
 
 .. |async| replace:: ``async``
 .. _async: https://github.com/rssh/dotty-cps-async/blob/master/shared/src/main/scala/cps/Async.scala#L30

--- a/docs/MonadsInteroperability.rst
+++ b/docs/MonadsInteroperability.rst
@@ -3,7 +3,7 @@ Monads interoperability.
 
 Monads in |async|_ and |await|_ can have different types, i.e. ``await[F]`` can be applied inside ``async[G]``.
 
-So we define the trait |CpsMonadConversion[F, G]|_ to support the conversion from ``F[_]`` to ``G[_]``.
+We define the trait |CpsMonadConversion[F, G]|_ to support the conversion from ``F[_]`` to ``G[_]``.
 
 ``Future`` Examples
 -------------------
@@ -25,7 +25,7 @@ Here is an example of implementation of ``Conversion`` from |Future|_ to any asy
                                          listener => ft.onComplete(listener) )
 
 
-Here 'async monad' for ``G[_]`` means it is possible to receive ``G[T]`` from a callback, which returns ``T``.
+Here, 'async monad' for ``G[_]`` means it is possible to receive ``G[T]`` from a callback, which returns ``T``.
 
 
 .. code-block:: scala
@@ -34,7 +34,7 @@ Here 'async monad' for ``G[_]`` means it is possible to receive ``G[T]`` from a 
 
    /**
     * called by the source, which accept callback.
-    * source is called immediatly in adoptCallbackStyle
+    * source is called immediately in adoptCallbackStyle
     **/
    def adoptCallbackStyle[A](source: (Try[A] => Unit) => Unit): F[A]
 
@@ -62,7 +62,7 @@ After making this definition available, we can await |Future|_ inside any async 
 
 And how about inserting ``await[F]`` into a ``async[Future]`` block ?
 
-For this it should mean, that our ``F`` should be able to schedule operation:
+For this, it means that our ``F`` should be able to schedule operation:
 
 .. code-block:: scala
 
@@ -70,14 +70,14 @@ For this it should mean, that our ``F`` should be able to schedule operation:
 
    /**
     * schedule execution of op somewhere.
-    * Note, that characteristics of scheduler can vary.
+    * Note, that characteristics of scheduler may vary.
     **/
    def spawn[A](op: => F[A]): F[A]
 
  }
 
 
-This can be immediatly evaluated for imperative monads, or for monads with delayed evaluation, 
+This can be immediately evaluated for imperative monads, or for monads with delayed evaluation,
 like Haskell-like IO -- submitting the ``op`` argument to a pull, which should be evaluated during ``unsafePerformIO`` at the end of the world.
 
 You can read implementation of conversion of scheduled monad to |Future|_ in the source file |FutureAsyncMonad.scala|_.
@@ -87,7 +87,8 @@ Of course, it is possible to create other conversions between your monads, based
 js.Promise
 -----------
 
-Not only monads can be subject to await. For example, it is impossible to attach monad structure to |Promise|_ in |Scala.js|_, because the map operation is unimplementable: all |Promise|_ operations flatten their arguments.  But we can await |Promise|_ from Scala ``async[Future]`` blocks, because |CpsMonadConversion[Future, Promise]|_ is defined.
+Not only monads can be subject to await. For example, it is impossible to attach the  monadic structure to |Promise|_ in |Scala.js|_, because the map operation is unimplementable: all |Promise|_ operations flatten their arguments.
+But we can still await |Promise|_ from Scala ``async[Future]`` blocks, because |CpsMonadConversion[Future, Promise]|_ is defined.
 
 Also, for a fluent implementation of JS facades, |dotty-cps-async|_ provides the |JSFuture|_ trait, which has monadic operations in Scala and visible from JavaScript as |Promise|_.  
 i.e. with the following definitions:

--- a/docs/ReturningClause.rst
+++ b/docs/ReturningClause.rst
@@ -1,8 +1,7 @@
 Non-local returns
 =================
 
-You can use `returning <https://scala-lang.org/api/3.x/scala/util/control/NonLocalReturns$.html>`_ clause inside async block as the same way  
-as in plain scala:
+You can use `returning <https://scala-lang.org/api/3.x/scala/util/control/NonLocalReturns$.html>`_ clause inside async block just like in plain Scala:
 
 .. code-block:: scala
 
@@ -41,7 +40,7 @@ Also, as in plain Scala, `throwReturn` does not intersect with handling `NonFata
 
 
 
-Now dotty-cps-async uses compile-time translation to avoid runtime overhead when this future is not used, so when using return 
+Dotty-cps-async uses compile-time translation to avoid runtime overhead when this future is not used, so when using return
 you should not hide catching `NonFatal` exceptions and `throwReturn` clauses from the `async` macro.
 
 If you want to change the function name for `throwReturn`, be sure that your version is `transparent inline`:

--- a/docs/RuntimeAwait.rst
+++ b/docs/RuntimeAwait.rst
@@ -5,7 +5,7 @@ Runtime Await.
 Starting from JDK-19,  the JVM provides lightweight concurrency constructions for representing non-blocking computations in 
 synchronous form. 
 
-We can use those constructions for some monads to escape the need to write shifted variants of high-order functions and,
+We can use those constructions for some monads, to escape the need to write shifted variants of high-order functions and,
 in some cases, work without the cps transformation of the code inside the `async` macro.
 
 To utilize these possibilities for your monad,  you should implement 
@@ -18,7 +18,7 @@ Also,  declare  `given cps.macro.flags.UseLoom.type`  value to enable this featu
 Note that for most effect systems, the cps transformation is still beneficial because of performance reasons. 
 When processing runtime awaits,  an effect interpreter should start all code thunks, including synchronous API usage,  
 in the new virtual thread. 
-Therefore, a hybrid mode, when effect interpretation is based on non-blocking code, and the system starts a virtual thread 
-only for arguments of hight-order functions, can be more performant.
+Therefore, an hybrid mode, where effect interpretation is based on non-blocking code, and the system starts a virtual thread
+only for arguments of high-order functions, can be more performant.
 
 


### PR DESCRIPTION
In reference to #48, I fixed some typos that I found while reading the docs, and rewrote some phrases to be more clear. Let me know if I wrote anything wrong.