### PR TITLE
Remove deprecated warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val dottyVersion = "3.2.2"
 
 ThisBuild/version := "0.9.17-SNAPSHOT"
 ThisBuild/versionScheme := Some("semver-spec")
-ThisBuild/resolvers += Opts.resolver.sonatypeSnapshots
+ThisBuild/resolvers ++= Opts.resolver.sonatypeOssSnapshots
 
 
 
@@ -37,8 +37,8 @@ lazy val cps = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     .disablePlugins(SitePreviewPlugin)
     .jvmSettings(
         scalacOptions ++= Seq( "-Yexplicit-nulls",
-                            "-unchecked", "-Ydebug-trace", "-Ydebug-names", "-Xprint-types", 
-                            "-Ydebug", "-uniqid", "-Xcheck-macros", "-Ycheck:macro", "-Yprint-syms", 
+                            "-unchecked", "-Ydebug-trace", "-Ydebug-names", "-Xprint-types",
+                            "-Ydebug", "-uniqid", "-Xcheck-macros", "-Ycheck:macro", "-Yprint-syms",
                             "-Ysafe-init",
                              ),
                              // -explain

--- a/shared/src/main/scala/cps/macros/Async.scala
+++ b/shared/src/main/scala/cps/macros/Async.scala
@@ -64,7 +64,7 @@ object Async {
           transformMonad[F,T,C](f,dm,c)
        case None =>
           val msg = s"Can't find async monad for ${TypeRepr.of[F].show} (transformImpl)"
-          report.throwError(msg, f)
+          report.errorAndAbort(msg, f)
 
              
   /**
@@ -111,7 +111,7 @@ object Async {
                   else  
                      '{  ${dm}.lazyPure(${transformed}) }
                else
-                  report.throwError(s"loom enbled but monad  ${dm.show} of type ${dm.asTerm.tpe.widen.show} is not Async, runtimeAwait = ${cpsRuntimeAwait.show}")
+                  report.errorAndAbort(s"loom enbled but monad  ${dm.show} of type ${dm.asTerm.tpe.widen.show} is not Async, runtimeAwait = ${cpsRuntimeAwait.show}")
               } else {
                val cpsExpr = rootTransform[F,T,C](f,dm,mc,memoization, optRuntimeAwait, flags,observatory, 0, None)
                if (DEBUG) {
@@ -153,7 +153,7 @@ object Async {
       case ex: MacroError =>
         if (flags.debugLevel > 0)
            ex.printStackTrace
-        report.throwError(ex.msg, ex.posExpr)
+        report.errorAndAbort(ex.msg, ex.posExpr)
 
 
 
@@ -311,10 +311,10 @@ object Async {
             case Lambda(params,body) =>
                params match
                   case List(vd) => (params, body, identity)
-                  case _ => report.throwError(s"lambda with one argument expected, we have ${params}",cexpr)
+                  case _ => report.errorAndAbort(s"lambda with one argument expected, we have ${params}",cexpr)
             case Block(Nil,nested@Lambda(params,body)) => extractLambda(nested)
             case _ =>
-               report.throwError(s"lambda expected, have: ${f}", cexpr)
+               report.errorAndAbort(s"lambda expected, have: ${f}", cexpr)
       
       def transformNotInlined(t: Term): Term =
          val (oldParams, body, nestFun) = extractLambda(t)

--- a/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
@@ -67,7 +67,7 @@ trait ApplyTreeTransform[F[_],CT, CC<:CpsMonadContext[F]]:
       if (cpsCtx.flags.debugLevel >= 15 && name=="apply")
           println(s"sameSelect: funTerm=${funTerm}")
           println(s"sameSelect: funTerm.tpe.typeSymbol=${funTerm.tpe.typeSymbol}")
-      funTerm.tpe.typeSymbol.memberMethod(name) match
+      funTerm.tpe.typeSymbol.methodMember(name) match
         case Nil => None
         case m::Nil =>
            val select = Select.unique(funTerm, name)
@@ -566,7 +566,7 @@ trait ApplyTreeTransform[F[_],CT, CC<:CpsMonadContext[F]]:
            else 
              TypeApply(t, targs)
 
-         qual.tpe.typeSymbol.memberMethod(shiftedName) match
+         qual.tpe.typeSymbol.methodMember(shiftedName) match
            case Nil =>
              Left(List())
            case m::Nil =>
@@ -675,7 +675,7 @@ trait ApplyTreeTransform[F[_],CT, CC<:CpsMonadContext[F]]:
                                    } else {
                                      shiftType.typeSymbol
                                    }
-                   shiftSymbol.memberMethod(xName) match
+                   shiftSymbol.methodMember(xName) match
                      case Nil =>
                         cpsCtx.runtimeAwait match
                            case None =>

--- a/shared/src/main/scala/cps/macros/misc/CollectionHelper.scala
+++ b/shared/src/main/scala/cps/macros/misc/CollectionHelper.scala
@@ -18,7 +18,7 @@ object CollectionHelper {
       if (companion.tpe <:< TypeRepr.of[IterableFactory[CC]]) then
         companion.asExprOf[IterableFactory[CC]]
       else
-        report.throwError(s"companion for ${ccTpe.show} is not an IterableFactory")
+        report.errorAndAbort(s"companion for ${ccTpe.show} is not an IterableFactory")
     }
 
 }

--- a/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
+++ b/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
@@ -115,7 +115,7 @@ class ArrayOpsAsyncShift[A] extends AsyncShift[ArrayOps[A]] {
            monad.map(f(e)){ b =>
               if ! s._1.contains(b) then {
                  s._2.addOne(e)
-                 (s._1 + b, s._2)
+                 (s._1.union(Set(b)), s._2)
               } else s
            }
          }

--- a/shared/src/main/scala/cps/runtime/SeqAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/SeqAsyncShift.scala
@@ -5,7 +5,7 @@ import scala.collection._
 import scala.reflect.ClassTag
 import scala.collection.mutable.ArrayBuilder
 
-class SeqAsyncShift[A, C[X] <: scala.collection.Seq[X] & scala.collection.SeqOps[X,C,C[X]], CA <: C[A]] 
+class SeqAsyncShift[A, C[X] <: scala.collection.Seq[X] & scala.collection.SeqOps[X,C,C[X]], CA <: C[A]]
        extends IterableOpsAsyncShift[A,C,CA]
            with PartialFunctionAsyncShiftBase[Int,A,CA]
    {
@@ -13,10 +13,9 @@ class SeqAsyncShift[A, C[X] <: scala.collection.Seq[X] & scala.collection.SeqOps
 
   // TODO: move to IndexedSeq
   def aggregate[F[_], B](c:C[A], m: CpsMonad[F])(
-        z: () => F[B])(seqop: (B, A) => F[B], combop: (B, B) ⇒ F[B]): F[B] =
-     c.aggregate[F[B]](z())(
+        z: () => F[B])(seqop: (B, A) => F[B]): F[B] =
+    c.foldLeft[F[B]](z())(
             (fb, a) => m.flatMap(fb)(b=>seqop(b,a)),
-            (fbx, fby) => m.flatMap(fbx)(bx=>m.flatMap(fby)(by=>combop(bx,by)))
      )
                       
   def distinctBy[F[_],B](c:CA, m: CpsMonad[F])(f: (A)=>F[B]): F[C[A]] =


### PR DESCRIPTION
This PR cleans up some deprecated elements. In detail:

- sonatypeOssSnapshots used in place of sonatypeSnapshots
-  errorAndAbort used in place of throwError [(deprecated from 3.1.0)](https://github.com/lampepfl/dotty/blob/7226ba60d443fae040ab5a95294ff773d6b71775/library/src/scala/quoted/Quotes.scala#L4661)
- methodMember used in place of memberMethod [(deprecated from 3.1.0)](https://github.com/lampepfl/dotty/blob/7226ba60d443fae040ab5a95294ff773d6b71775/library/src/scala/quoted/Quotes.scala#L4003)
- Set.union used in place of overloaded  **+** [(deprecated from 2.13.0)](https://github.com/scala/scala/blob/v2.13.10/src/library/scala/collection/Set.scala#L240)
- foldLeft instead of aggregate for sequential collections [(deprecated since 2.13.0)](https://github.com/scala/scala/blob/v2.13.10/src/library/scala/collection/IterableOnce.scala#L1123)

Because of the last change, the *aggregate* method of **SeqAsyncShift** now takes one less parameter.