### PR TITLE
Fix indent on BasicUsage.rst

### DIFF
--- a/docs/BasicUsage.rst
+++ b/docs/BasicUsage.rst
@@ -33,7 +33,7 @@ for sbt:
 
 for mill:
 
-    .. code-block:: scala
+ .. code-block:: scala
 
   def scalacPluginIvyDeps = Agg(ivy"com.github.rssh::dotty-cps-async-compiler-plugin:0.9.21")
 


### PR DESCRIPTION
I noticed that it is a bit off on this page  https://rssh.github.io/dotty-cps-async/BasicUsage.html#sbt-example