### PR TITLE
Fix ArrayOpsAsyncShift.dropWhile returning head instead of empty when all match

### DIFF
--- a/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
+++ b/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
@@ -129,7 +129,7 @@ class ArrayOpsAsyncShift[A] extends AsyncShift[ArrayOps[A]] {
 
   def dropWhile[F[_]](arr: ArrayOps[A], monad: CpsMonad[F])(p: A => F[Boolean]): F[Array[A]] = {
     def skipWhile(it: Iterator[A], i: Int): F[Array[A]] =
-      if !it.hasNext then monad.pure(arr.slice(0, 1))
+      if !it.hasNext then monad.pure(arr.slice(0, 0))
       else
         val e = it.next
         monad.flatMap(p(e)) { v =>

--- a/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
@@ -100,7 +100,7 @@ class TestCBS1ShiftArrayOps:
         case Success(v) =>
             assert(v.isEmpty)
         case Failure(ex) =>
-            assert(false,"dropWhile on empty array should be successed")
+            assert(false,"dropWhile on empty array should be succeeded")
      }
 
   @Test def testExistsT(): Unit =

--- a/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
@@ -81,6 +81,28 @@ class TestCBS1ShiftArrayOps:
             assert(false,"dropWhile result should be successed")
      }
 
+  @Test def testDropWhileAllMatch(): Unit =
+     val c = async[ComputationBound]{
+               Array(T1.cbi(1),T1.cbi(2),T1.cbi(3)).dropWhile(x => await(x) < 10)
+             }
+     c.run() match {
+        case Success(v) =>
+            assert(v.isEmpty, s"dropWhile when all match should be empty, got length ${v.length}")
+        case Failure(ex) =>
+            assert(false,"dropWhile result should be successed")
+     }
+
+  @Test def testDropWhileEmpty(): Unit =
+     val c = async[ComputationBound]{
+               Array.empty[ComputationBound[Int]].dropWhile(x => await(x) < 10)
+             }
+     c.run() match {
+        case Success(v) =>
+            assert(v.isEmpty)
+        case Failure(ex) =>
+            assert(false,"dropWhile on empty array should be successed")
+     }
+
   @Test def testExistsT(): Unit =
      val c = async[ComputationBound]{
                 Array(T1.cbi(1),T1.cbi(2),T1.cbi(3)).exists(x => await(x)==2)


### PR DESCRIPTION
## Summary
- Fix off-by-one in `ArrayOpsAsyncShift.dropWhile`: the iterator-exhausted branch used `arr.slice(0, 1)` where `slice(0, 0)` was intended, so `dropWhile` returned a one-element prefix instead of an empty array when every element matched the predicate.
- Add regression tests for the all-match and empty-array cases.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/123) and proposed fix.

Closes #123

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestCBS1ShiftArrayOps` — all 33 tests pass (including 2 new ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)