### PR TITLE
Fix EitherAsyncShift.forall returning false for Left

### DIFF
--- a/shared/src/main/scala/cps/runtime/util/EitherAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/EitherAsyncShift.scala
@@ -30,7 +30,7 @@ class EitherAsyncShift[A, B] extends AsyncShift[Either[A, B]]:
 
   def forall[F[_]](o: Either[A, B], m: CpsMonad[F])(p: (B) => F[Boolean]): F[Boolean] =
     o match
-      case Left(a)  => m.pure(false)
+      case Left(a)  => m.pure(true)
       case Right(b) => p(b)
 
   def foreach[F[_], U](o: Either[A, B], m: CpsMonad[F])(f: (B) => F[U]): F[Unit] =

--- a/shared/src/test/scala/cps/TestCBS1ShiftEither.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftEither.scala
@@ -31,7 +31,7 @@ class TestBS1ShiftEither:
      }
      assert(c.run() == Success(2))
 
-  @Test def testEitherLeftForAll1(): Unit = 
+  @Test def testEitherLeftForAll1(): Unit =
      //implicit val printCode = cps.macroFlags.PrintCode
      //implicit val debugLevel = cps.macroFlags.DebugLevel(20)
      val c = async[ComputationBound]{
@@ -39,6 +39,27 @@ class TestBS1ShiftEither:
         a.left.forall{ _ == await(T1.cbs("A")) }
      }
      assert(c.run() == Success(true))
+
+  @Test def testEitherForAllLeftIsVacuouslyTrue(): Unit =
+     val c = async[ComputationBound]{
+        val a: Either[String,Int] = Left("A")
+        a.forall(_ == await(T1.cbi(0)))
+     }
+     assert(c.run() == Success(true))
+
+  @Test def testEitherForAllRightTrue(): Unit =
+     val c = async[ComputationBound]{
+        val a: Either[String,Int] = Right(5)
+        a.forall(_ == await(T1.cbi(5)))
+     }
+     assert(c.run() == Success(true))
+
+  @Test def testEitherForAllRightFalse(): Unit =
+     val c = async[ComputationBound]{
+        val a: Either[String,Int] = Right(5)
+        a.forall(_ == await(T1.cbi(0)))
+     }
+     assert(c.run() == Success(false))
 
 
 


### PR DESCRIPTION
## Summary
- `scala.util.Either.forall` is vacuously `true` on `Left`, but `EitherAsyncShift.forall` returned `m.pure(false)`, so any `someEither.forall(asyncPredicate)` inside an `async` block silently flipped the result for `Left`.
- Sibling methods are unaffected: `Either.exists` (returns `false` on `Left`) and `LeftProjection.forall` (returns `true` on the non-`Left` branch) already match the standard library.
- Add regression tests covering `Left` (vacuous true) and both `Right` outcomes.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/119) and proposed fix.

Closes #119

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftEither` — 6 tests pass (3 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)