### PR TITLE
Fix TryAsyncShift.recover/recoverWith MatchError on unhandled exceptions

### DIFF
--- a/shared/src/main/scala/cps/runtime/util/TryAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/TryAsyncShift.scala
@@ -47,12 +47,16 @@ class TryAsyncShift[T] extends AsyncShift[Try[T]]:
   def recover[F[_], U >: T](o: Try[T], m: CpsMonad[F])(pf: PartialFunction[Throwable, F[U]]): F[Try[U]] =
     o match
       case Success(t)  => m.pure(Success(t))
-      case Failure(ex) => m.map(pf(ex))(u => Success(u))
+      case Failure(ex) =>
+        if pf.isDefinedAt(ex) then m.map(pf(ex))(u => Success(u))
+        else m.pure(Failure(ex))
 
   def recoverWith[F[_], U >: T](o: Try[T], m: CpsMonad[F])(pf: PartialFunction[Throwable, F[Try[U]]]): F[Try[U]] =
     o match
       case Success(t)  => m.pure(Success(t))
-      case Failure(ex) => pf(ex)
+      case Failure(ex) =>
+        if pf.isDefinedAt(ex) then pf(ex)
+        else m.pure(Failure(ex))
 
 object TryModuleAsyncShift extends AsyncShift[Try.type]:
 

--- a/shared/src/main/scala/cps/runtime/util/TryAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/TryAsyncShift.scala
@@ -54,9 +54,7 @@ class TryAsyncShift[T] extends AsyncShift[Try[T]]:
   def recoverWith[F[_], U >: T](o: Try[T], m: CpsMonad[F])(pf: PartialFunction[Throwable, F[Try[U]]]): F[Try[U]] =
     o match
       case Success(t)  => m.pure(Success(t))
-      case Failure(ex) =>
-        if pf.isDefinedAt(ex) then pf(ex)
-        else m.pure(Failure(ex))
+      case Failure(ex) => pf.applyOrElse(ex, (e: Throwable) => m.pure(Failure(e)))
 
 object TryModuleAsyncShift extends AsyncShift[Try.type]:
 

--- a/shared/src/test/scala/cps/TestCBS1ShiftTry.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftTry.scala
@@ -20,7 +20,7 @@ class TestBS1ShiftTry:
      assert(c.run() == Success(Success(2)))
 
 
-  @Test def testTryGetOrElse0(): Unit = 
+  @Test def testTryGetOrElse0(): Unit =
      //implicit val printCode = cps.macroFlags.PrintCode
      //implicit val debugLevel = cps.macroFlags.DebugLevel(20)
      val c = async[ComputationBound]{
@@ -30,6 +30,36 @@ class TestBS1ShiftTry:
         }
      }
      assert(c.run() == Success(0))
+
+  @Test def testTryRecoverMatched(): Unit =
+     val c = async[ComputationBound]{
+        val a: Try[Int] = Failure(new IllegalArgumentException("bad"))
+        a.recover{ case _: IllegalArgumentException => await(T1.cbi(42)) }
+     }
+     assert(c.run() == Success(Success(42)))
+
+  @Test def testTryRecoverUnmatchedPreservesFailure(): Unit =
+     val ex = new RuntimeException("boom")
+     val c = async[ComputationBound]{
+        val a: Try[Int] = Failure(ex)
+        a.recover{ case _: IllegalArgumentException => await(T1.cbi(42)) }
+     }
+     assert(c.run() == Success(Failure(ex)))
+
+  @Test def testTryRecoverWithMatched(): Unit =
+     val c = async[ComputationBound]{
+        val a: Try[Int] = Failure(new IllegalArgumentException("bad"))
+        a.recoverWith{ case _: IllegalArgumentException => Success(await(T1.cbi(7))) }
+     }
+     assert(c.run() == Success(Success(7)))
+
+  @Test def testTryRecoverWithUnmatchedPreservesFailure(): Unit =
+     val ex = new RuntimeException("boom")
+     val c = async[ComputationBound]{
+        val a: Try[Int] = Failure(ex)
+        a.recoverWith{ case _: IllegalArgumentException => Success(await(T1.cbi(7))) }
+     }
+     assert(c.run() == Success(Failure(ex)))
 
 /*
   @Test def testEitherGetOrElse1(): Unit = 


### PR DESCRIPTION
## Summary
- `Try.recover`/`recoverWith` are documented to leave the original `Failure` alone when the partial function does not match. The async-shifted versions called `pf(ex)` unconditionally, so an unmatched exception turned into a `MatchError` crash.
- Add `isDefinedAt` guards in both `recover` and `recoverWith`, falling back to `m.pure(Failure(ex))` when the PF is not defined.
- Add 4 regression tests: matched/unmatched cases for both `recover` and `recoverWith`.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/120) and proposed fix.

Closes #120

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftTry` — 6 tests pass (2 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)