### PR TITLE
Fix UsingAsyncShift.apply leaking the resource on the failure path

### DIFF
--- a/shared/src/main/scala/cps/runtime/util/UsingAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/UsingAsyncShift.scala
@@ -9,9 +9,7 @@ object UsingAsyncShift extends AsyncShift[Using.type]:
       resource: () => F[R]
   )(f: (R) => F[A])(implicit arg0: Using.Releasable[R]): F[Try[A]] = {
     m.flatMap(resource())(r =>
-      m.restore(
-        m.map(f(r))(x => { arg0.release(r); Success(x) })
-      )(e => m.pure(Failure(e)))
+      m.mapTry(m.withAction(f(r))(arg0.release(r)))(identity)
     )
   }
 

--- a/shared/src/test/scala/cps/TestCBS1ShiftUsing.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftUsing.scala
@@ -117,9 +117,8 @@ class TestBS1ShiftUsing:
      val r = new TestResource("apply-failure")
      val c = async[ComputationBound]{
          Using(r){ r =>
-             val q = await(T1.cbs(r.label))
+             await(T1.cbs(r.label))
              throw new RuntimeException("testUsingApplyClosesOnFailure")
-             q
          }
      }
      val res = c.run()

--- a/shared/src/test/scala/cps/TestCBS1ShiftUsing.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftUsing.scala
@@ -101,6 +101,34 @@ class TestBS1ShiftUsing:
      assert(svR3.get.isClosed == true)
 
 
+  @Test def testUsingApplyClosesOnSuccess(): Unit =
+     val r = new TestResource("apply-success")
+     val c = async[ComputationBound]{
+         Using(r){ r =>
+             val q = await(T1.cbs(r.label))
+             r.log(q)
+             q
+         }
+     }
+     assert(c.run() == Success(Success("apply-success")))
+     assert(r.isClosed)
+
+  @Test def testUsingApplyClosesOnFailure(): Unit =
+     val r = new TestResource("apply-failure")
+     val c = async[ComputationBound]{
+         Using(r){ r =>
+             val q = await(T1.cbs(r.label))
+             throw new RuntimeException("testUsingApplyClosesOnFailure")
+             q
+         }
+     }
+     val res = c.run()
+     assert(res.isSuccess, s"outer monad should be Success, got $res")
+     res match
+       case Success(inner) => assert(inner.isFailure, s"inner Try should be Failure, got $inner")
+       case _ => assert(false)
+     assert(r.isClosed, "resource leaked on failure path")
+
   @Test def testUsingResources4(): Unit =
      var svR2: Option[TestResource] = None;
      var svR3: Option[TestResource] = None;


### PR DESCRIPTION
## Summary
- `scala.util.Using.apply(resource)(f)` is documented to release the resource even when `f` throws. The async-shifted `apply` only released on the success continuation; the `m.restore` error branch returned `Failure(e)` without calling `release`, so a failing body leaked the resource.
- Replace the success/restore pair with `m.withAction(f(r))(release(r))` followed by `m.mapTry(_)(identity)` — the same pattern the sibling `resource`/`resources` methods already use. `withAction` releases on both paths.
- Add 2 regression tests: success path (resource closed, value returned) and failure path (resource closed, inner `Try` is `Failure`).

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/121) and proposed fix.

Closes #121

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftUsing` — 8 tests pass (6 existing + 2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)