### PR TITLE
Fix IndexedSeqAsyncShift.indexWhere ignoring the from parameter

### DIFF
--- a/shared/src/main/scala/cps/runtime/SeqAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/SeqAsyncShift.scala
@@ -90,7 +90,7 @@ class IndexedSeqAsyncShift[A, C[X] <: IndexedSeq[X] & IndexedSeqOps[X, C, C[X]],
           else run(n + 1)
         }
       else m.pure(-1)
-    run(0)
+    run(math.max(0, from))
 
   override def indexWhere[F[_]](c: CA, m: CpsMonad[F])(p: A => F[Boolean]): F[Int] =
     indexWhere(c, m)(p, 0)

--- a/shared/src/test/scala/cps/TestCBS1ShiftSeq.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftSeq.scala
@@ -59,12 +59,33 @@ class TestBS1ShiftSeq:
 */
 
 
-  @Test def testIndexWhereIndexed(): Unit = 
+  @Test def testIndexWhereIndexed(): Unit =
      val c = async[ComputationBound]{
         val seq = IndexedSeq("1234","3452","1","12","21","777777777")
         seq.indexWhere{ x => await(T1.cbt(x.charAt(0)=='7')) }
      }
      assert(c.run()==Success(5))
+
+  @Test def testIndexWhereIndexedFromHonored(): Unit =
+     val c = async[ComputationBound]{
+        val seq = IndexedSeq(1,2,3,4,3,5)
+        seq.indexWhere(x => await(T1.cbt(x == 3)), 3)
+     }
+     assert(c.run() == Success(4))
+
+  @Test def testIndexWhereIndexedFromBeyondEnd(): Unit =
+     val c = async[ComputationBound]{
+        val seq = IndexedSeq(1,2,3,4,3,5)
+        seq.indexWhere(x => await(T1.cbt(x == 3)), 10)
+     }
+     assert(c.run() == Success(-1))
+
+  @Test def testIndexWhereIndexedFromNegative(): Unit =
+     val c = async[ComputationBound]{
+        val seq = IndexedSeq(1,2,3,4,3,5)
+        seq.indexWhere(x => await(T1.cbt(x == 3)), -2)
+     }
+     assert(c.run() == Success(2))
 
   @Test def testSegmentLength(): Unit = 
      val c = async[ComputationBound]{


### PR DESCRIPTION
## Summary
- The `IndexedSeq`-optimised `indexWhere(p, from)` override accepted `from` in its signature but started the recursion at `run(0)`, so searches always began at index 0 and could return a position smaller than `from`.
- Fix: `run(math.max(0, from))` — honour `from` while clamping negative values to 0, matching `scala.collection.SeqOps.indexWhere`.
- The base `SeqAsyncShift.indexWhere` (which uses `advanceIterator(c, from)`) was already correct, as was the sibling `segmentLength(p, from)` override in this class.
- Add 3 regression tests on `IndexedSeq`: explicit `from`, `from` past end, negative `from`.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/122) and proposed fix.

Closes #122

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftSeq` — 9 tests pass (6 existing + 3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)