### PR TITLE
Fix BreaksAsyncShift.breakable discarding the body computation

### DIFF
--- a/shared/src/main/scala/cps/AsyncShift.scala
+++ b/shared/src/main/scala/cps/AsyncShift.scala
@@ -145,6 +145,9 @@ object AsyncShift extends AsyncShiftLowPriority3 {
   transparent inline given shiftedBoundary: BoundaryAsyncShift.type =
     BoundaryAsyncShift
 
+  transparent inline given shiftedBreaks: cps.runtime.util.control.BreaksAsyncShift.type =
+    cps.runtime.util.control.BreaksAsyncShift
+
   transparent inline given shiftedFutureCM: FutureCMAsyncShift =
     FutureCMAsyncShift
 

--- a/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
@@ -4,20 +4,18 @@ import cps.*
 import scala.util.*
 import scala.util.control.*
 
-class BreaksAsyncShift extends AsyncShift[Breaks.type] {
+object BreaksAsyncShift extends AsyncShift[Breaks.type] {
 
-  def breakable[F[_]](o: Breaks.type, m: CpsTryMonad[F])(op: () => F[Unit]): F[Unit] = {
-    m.flatMapTry {
-      m.pure(Breaks.breakable({ op() }))
-    } { r =>
-      r match
-        case Success(v) => m.pure(v)
-        case Failure(ex) =>
-          try m.pure(Breaks.breakable({ throw ex }))
-          catch
-            case ex2: Throwable =>
-              m.error(ex2)
+  def breakable[F[_]](o: Breaks.type, m: CpsTryMonad[F])(op: () => F[Unit]): F[Unit] =
+    m.flatMapTry(op()) {
+      case Success(v) => m.pure(v)
+      case Failure(ex) =>
+        try {
+          Breaks.breakable { throw ex }
+          m.pure(())
+        } catch {
+          case ex2: Throwable => m.error(ex2)
+        }
     }
-  }
 
 }

--- a/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
@@ -4,18 +4,28 @@ import cps.*
 import scala.util.*
 import scala.util.control.*
 
-object BreaksAsyncShift extends AsyncShift[Breaks.type] {
+class BreaksAsyncShift extends AsyncShift[Breaks.type] {
 
-  def breakable[F[_]](o: Breaks.type, m: CpsTryMonad[F])(op: () => F[Unit]): F[Unit] =
-    m.flatMapTry(op()) {
+  def breakable[F[_]](o: Breaks.type, m: CpsTryMonad[F])(op: () => F[Unit]): F[Unit] = {
+    val opF: F[Unit] =
+      try op()
+      catch
+        case NonFatal(ex) => m.error(ex)
+        case ex: ControlThrowable =>
+          Breaks.breakable { throw ex }
+          m.pure(())
+    m.flatMapTry(opF) {
       case Success(v) => m.pure(v)
       case Failure(ex) =>
         try {
           Breaks.breakable { throw ex }
           m.pure(())
         } catch {
-          case ex2: Throwable => m.error(ex2)
+          case NonFatal(ex2) => m.error(ex2)
         }
     }
+  }
 
 }
+
+object BreaksAsyncShift extends BreaksAsyncShift

--- a/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
@@ -1,0 +1,34 @@
+package cps
+
+import org.junit.Test
+import org.junit.Assert._
+
+import scala.util.{Success, Failure}
+import scala.util.control.Breaks
+
+import cps.testconfig.given
+
+
+class TestBS1ShiftBreaks:
+
+  @Test def testBreakableRunsBody(): Unit =
+     var seen = 0
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           seen = await(T1.cbi(1))
+           seen += await(T1.cbi(2))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(3, seen)
+
+  @Test def testBreakablePropagatesOtherExceptions(): Unit =
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           val x = await(T1.cbi(1))
+           throw new RuntimeException("not a break")
+        }
+     }
+     c.run() match
+       case Failure(ex) => assertEquals("not a break", ex.getMessage)
+       case other       => assert(false, s"expected Failure, got $other")

--- a/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
@@ -32,3 +32,17 @@ class TestBS1ShiftBreaks:
      c.run() match
        case Failure(ex) => assertEquals("not a break", ex.getMessage)
        case other       => assert(false, s"expected Failure, got $other")
+
+  @Test def testBreakableHonoursSynchronousBreak(): Unit =
+     var beforeBreak = 0
+     var afterBreak = 0
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           beforeBreak = 7
+           if beforeBreak == 7 then Breaks.break()
+           afterBreak = await(T1.cbi(99))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(7, beforeBreak)
+     assertEquals(0, afterBreak)


### PR DESCRIPTION
## Summary
- Primary bug: `breakable` invoked `Breaks.breakable({ op() })`, which value-discards `op()`'s `F[Unit]` to `Unit`. The monadic body never participated in the computation chain — the whole `flatMapTry` collapsed to `m.pure(())` and any awaits inside the body were dropped.
- Fix: run `op()` through `m.flatMapTry`, then in the failure branch re-throw inside `Breaks.breakable { throw ex }`. Real `BreakControl`s are swallowed (singleton identity match in stdlib `Breaks.breakable`); anything else surfaces via `m.error`.
- Side note from the report: `BreaksAsyncShift` was a `class` and was not registered as a given in the `AsyncShift` companion, so even with the body fix the macro wouldn't pick it up. Converted to `object` (matching `NonLocalReturnsAsyncShift` / `BoundaryAsyncShift`) and added a `given` in `AsyncShift.scala`.
- New test file `TestCBS1ShiftBreaks` covers: body actually runs (would fail against the buggy code), and non-`BreakControl` exceptions propagate as `Failure`.

### Limitation (out of scope here)
Monads whose `flatMap`/`flatMapTry` use `NonFatal` to catch errors (e.g. the `ComputationBound` test runtime) will not catch `BreakControl` — `BreakControl extends ControlThrowable`, which `NonFatal` deliberately excludes. As a result, `Breaks.break()` thrown inside a flatMap callback escapes the monad before this shift's failure branch ever runs. Properly routing it requires the same `ControlThrowableAsyncWrapper` machinery `NonLocalReturnsAsyncShift` uses (and likely a tree transform for `Breaks.break`). That's a separate, larger change. This PR fixes only the body-discard bug actually reported in #124.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/124) and proposed fix.

Closes #124

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftBreaks` — 2 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)