### PR TITLE
Fix ArrayOpsAsyncShift.lastIndexWhere not clamping end

### DIFF
--- a/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
+++ b/shared/src/main/scala/cps/runtime/ArrayOpsAsynsShift.scala
@@ -270,7 +270,7 @@ class ArrayOpsAsyncShift[A] extends AsyncShift[ArrayOps[A]] {
         monad.flatMap(p(e)) { v =>
           if (v) then monad.pure(i) else steps(view, i - 1)
         }
-    steps(arrOps.view, end)
+    steps(arrOps.view, math.min(end, arrOps.size - 1))
   }
 
   def partition[F[_]](arrOps: ArrayOps[A], monad: CpsMonad[F])(p: A => F[Boolean]): F[(Array[A], Array[A])] = {

--- a/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftArrayOps.scala
@@ -272,6 +272,34 @@ class TestCBS1ShiftArrayOps:
      assert(r == 4)
    */
 
+  @Test def testLastIndexWhereEndPastLength(): Unit =
+     val c = async[ComputationBound]{
+          val arr = Array(1,2,3,4,5)
+          arr.lastIndexWhere(x => x > await(T1.cbi(3)), 100)
+     }
+     assert(c.run() == Success(4))
+
+  @Test def testLastIndexWhereEndInRange(): Unit =
+     val c = async[ComputationBound]{
+          val arr = Array(1,2,3,4,5)
+          arr.lastIndexWhere(x => x > await(T1.cbi(3)), 3)
+     }
+     assert(c.run() == Success(3))
+
+  @Test def testLastIndexWhereEndNegative(): Unit =
+     val c = async[ComputationBound]{
+          val arr = Array(1,2,3,4,5)
+          arr.lastIndexWhere(x => x > await(T1.cbi(3)), -1)
+     }
+     assert(c.run() == Success(-1))
+
+  @Test def testLastIndexWhereEmptyEndPastLength(): Unit =
+     val c = async[ComputationBound]{
+          val arr = Array.empty[Int]
+          arr.lastIndexWhere(x => x > await(T1.cbi(0)), 100)
+     }
+     assert(c.run() == Success(-1))
+
   /*
   bug in dotty: https://github.com/lampepfl/dotty/issues/17445
   @Test def testLastIndexWhere(): Unit =


### PR DESCRIPTION
## Summary
- Stdlib `ArrayOps.lastIndexWhere(p, end)` clamps `end` to `length - 1` before scanning. The async-shifted version handed `end` straight to the recursion, so any `end >= length` threw `IndexOutOfBoundsException` from the very first `view(i)`.
- Fix: `steps(arrOps.view, math.min(end, arrOps.size - 1))` — matches stdlib semantics. Negative `end` was already handled correctly by the existing `i < 0` guard, and an empty array now returns `-1` instead of throwing.
- 4 regression tests: `end` past length, `end` in range (smoke), negative `end`, empty array with out-of-range `end`.

The pre-existing commented-out `testLastIndexWhere` block referencing dotty issue 17445 is unrelated — that's the no-`end` overload, this PR doesn't touch it.

Thanks to @haskiindahouse for the [bug report](https://github.com/dotty-cps-async/dotty-cps-async/issues/125) and proposed fix.

Closes #125

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestCBS1ShiftArrayOps` — 35 tests pass (31 existing + 4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)