### PR TITLE
Route Breaks.break() through BreaksAsyncShift end-to-end

### DIFF
--- a/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
@@ -34,9 +34,9 @@ trait ApplyTreeTransform[F[_], CT, CC <: CpsMonadContext[F]]:
         runNonLocalReturnsReturning(applyTerm, fun, targs, args)(owner)
       case funTypeApply @ TypeApply(obj, targs) =>
         handleFunTypeApply(applyTerm, funTypeApply, args, obj, targs, tails)(owner)
-      case Select(obj, _) if fun.symbol == breaksBreakSym && obj.symbol == breaksModuleSym.companionModule =>
+      case Select(obj, _) if fun.symbol == breaksBreakSym && obj.tpe <:< breaksModuleSingletonType =>
         runBreaksBreak(applyTerm)(owner)
-      case Select(obj, _) if fun.symbol == breaksBreakableSym && obj.symbol == breaksModuleSym.companionModule =>
+      case Select(obj, _) if fun.symbol == breaksBreakableSym && obj.tpe <:< breaksModuleSingletonType =>
         runBreaksBreakable(applyTerm, fun, args)(owner)
       case Select(obj, method) =>
         if (fun.symbol == logicalAndSym || fun.symbol == logicalOrSym) then handleBooleanAndOr(applyTerm, fun, obj, args)(owner)

--- a/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/ApplyTreeTransform.scala
@@ -34,6 +34,10 @@ trait ApplyTreeTransform[F[_], CT, CC <: CpsMonadContext[F]]:
         runNonLocalReturnsReturning(applyTerm, fun, targs, args)(owner)
       case funTypeApply @ TypeApply(obj, targs) =>
         handleFunTypeApply(applyTerm, funTypeApply, args, obj, targs, tails)(owner)
+      case Select(obj, _) if fun.symbol == breaksBreakSym && obj.symbol == breaksModuleSym.companionModule =>
+        runBreaksBreak(applyTerm)(owner)
+      case Select(obj, _) if fun.symbol == breaksBreakableSym && obj.symbol == breaksModuleSym.companionModule =>
+        runBreaksBreakable(applyTerm, fun, args)(owner)
       case Select(obj, method) =>
         if (fun.symbol == logicalAndSym || fun.symbol == logicalOrSym) then handleBooleanAndOr(applyTerm, fun, obj, args)(owner)
         else handleFunSelect(applyTerm, fun, args, obj, method, tails)(owner)

--- a/shared/src/main/scala/cps/macros/forest/BreaksTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/BreaksTreeTransform.scala
@@ -1,0 +1,85 @@
+package cps.macros.forest
+
+import scala.quoted._
+
+import cps._
+import cps.macros._
+import cps.macros.misc._
+
+/** Transforms calls to `scala.util.control.Breaks.break()` and `Breaks.breakable { body }`
+  * inside an async block. `break()` is rewritten to `BreaksAsyncShift.break(Breaks)` so the
+  * thrown `BreakControl` is wrapped as a `NonFatal`-friendly `ControlThrowableAsyncWrapper`,
+  * letting the surrounding `breakable` shift catch it through the monad. The `breakable`
+  * body is also passed through `substituteNonFatal` so user-level `case NonFatal(_)` catches
+  * inside the body do not accidentally swallow the wrapper.
+  */
+trait BreaksTreeTransform[F[_], CT, CC <: CpsMonadContext[F]]:
+
+  thisScope: TreeTransformScope[F, CT, CC] =>
+
+  import qctx.reflect._
+
+  // Breaks.break()
+  def runBreaksBreak(applyTerm: Apply)(owner: Symbol): CpsTree = {
+    val shiftedCall =
+      Apply(
+        Select(shiftedBreaksObjectRef, shiftedBreaksBreakSym),
+        List(Ref.term(breaksModuleSym.companionModule.termRef))
+      )
+    CpsTree.pure(owner, shiftedCall, true)
+  }
+
+  // Breaks.breakable { body }
+  def runBreaksBreakable(applyTerm: Apply, fun: Term, args: List[Term])(owner: Symbol): CpsTree = {
+    if (cpsCtx.flags.debugLevel >= 10) {
+      cpsCtx.log("runBreaksBreakable")
+    }
+    val paramsDescriptor = MethodParamsDescriptor(fun)
+    val substituteNonFatal = new TreeMap {
+      override def transformTree(tree: Tree)(owner: Symbol): Tree = {
+        tree match
+          case u @ Unapply(fun, implicits, patterns) if fun.symbol == nonFatalUnapplySym =>
+            val nFun = Select.unique(nonFatalAndNotControlThrowableAsyncWrapperCompanion, "unapply")
+            Unapply.copy(u)(nFun, implicits, patterns)
+          case _ =>
+            super.transformTree(tree)(owner)
+      }
+    }
+    val nArgs = substituteNonFatal.transformTerms(args)(owner)
+    val argRecords = O.buildApplyArgsRecords(paramsDescriptor, nArgs)(owner)
+    // The single argument is the by-name `op: => Unit`.
+    argRecords.head match
+      case appRecord: ApplyArgByNameRecord =>
+        appRecord.cpsTree.syncOrigin match
+          case None =>
+            // Async body: build () => F[Unit] via the record's identArg with CPS_ONLY.
+            val shiftedArg = appRecord.shift().identArg(true)
+            val nTerm = Apply.copy(applyTerm)(
+              Apply(
+                TypeApply(
+                  Select(shiftedBreaksObjectRef, shiftedBreaksBreakableSym),
+                  List(TypeTree.of[F])
+                ),
+                List(Ref.term(breaksModuleSym.companionModule.termRef), cpsCtx.monad.asTerm)
+              ),
+              List(shiftedArg)
+            )
+            CpsTree.impure(owner, nTerm, applyTerm.tpe)
+          case Some(syncBody) =>
+            if (appRecord.cpsTree.isChanged) then
+              // Build a () => Unit lambda over the transformed sync body, route through syncBreakable
+              // so a wrapped break (from a rewritten Breaks.break()) is still recognised.
+              val mt = MethodType(List())(_ => List(), _ => TypeRepr.of[Unit])
+              val lambda = Lambda(owner, mt, (lamOwner, _) => syncBody.changeOwner(lamOwner))
+              val nTerm = Apply.copy(applyTerm)(
+                Apply(
+                  Select(shiftedBreaksObjectRef, shiftedBreaksSyncBreakableSym),
+                  List(Ref.term(breaksModuleSym.companionModule.termRef))
+                ),
+                List(lambda)
+              )
+              CpsTree.pure(owner, nTerm, true)
+            else CpsTree.pure(owner, applyTerm)
+      case _ =>
+        throw MacroError("Invalid argument for Breaks.breakable (should be by-name)", posExpr(applyTerm))
+  }

--- a/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
+++ b/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
@@ -42,6 +42,24 @@ trait KnownTreeFragments[F[_], CT, CC <: CpsMonadContext[F]]:
   lazy val shiftedNonLocalReturnsSyncReturningSym =
     Symbol.classSymbol("cps.runtime.util.control.NonLocalReturnsAsyncShift$").declaredMethod("syncReturning").head
 
+  lazy val breaksClassSym = Symbol.classSymbol("scala.util.control.Breaks")
+  lazy val breaksModuleSym = Symbol.classSymbol("scala.util.control.Breaks$")
+
+  lazy val breaksBreakSym = breaksClassSym.declaredMethod("break").head
+  lazy val breaksBreakableSym = breaksClassSym.declaredMethod("breakable").head
+
+  lazy val shiftedBreaksAsyncShiftSym =
+    Symbol.classSymbol("cps.runtime.util.control.BreaksAsyncShift$")
+  lazy val shiftedBreaksAsyncShiftClassSym =
+    Symbol.classSymbol("cps.runtime.util.control.BreaksAsyncShift")
+
+  // methods are declared on the `class BreaksAsyncShift`, inherited by the object.
+  lazy val shiftedBreaksBreakSym = shiftedBreaksAsyncShiftClassSym.declaredMethod("break").head
+  lazy val shiftedBreaksBreakableSym = shiftedBreaksAsyncShiftClassSym.declaredMethod("breakable").head
+  lazy val shiftedBreaksSyncBreakableSym = shiftedBreaksAsyncShiftClassSym.declaredMethod("syncBreakable").head
+
+  lazy val shiftedBreaksObjectRef = Ref.term(shiftedBreaksAsyncShiftSym.companionModule.termRef)
+
   lazy val nonFatalUnapplySym = Symbol.classSymbol("scala.util.control.NonFatal$").declaredMethod("unapply").head
 
   lazy val nonFatalAndNotControlThrowableAsyncWrapperClassSym =

--- a/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
+++ b/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
@@ -45,6 +45,13 @@ trait KnownTreeFragments[F[_], CT, CC <: CpsMonadContext[F]]:
   lazy val breaksClassSym = Symbol.classSymbol("scala.util.control.Breaks")
   lazy val breaksModuleSym = Symbol.classSymbol("scala.util.control.Breaks$")
 
+  /** Singleton type of the `scala.util.control.Breaks` companion. Used to match
+    * stable aliases of the singleton (e.g. `val b = Breaks; b.break()`), while
+    * still excluding `new Breaks` instances (whose static type is `Breaks`, not
+    * `Breaks.type`).
+    */
+  lazy val breaksModuleSingletonType = Ref.term(breaksModuleSym.companionModule.termRef).tpe
+
   lazy val breaksBreakSym = breaksClassSym.declaredMethod("break").head
   lazy val breaksBreakableSym = breaksClassSym.declaredMethod("breakable").head
 

--- a/shared/src/main/scala/cps/macros/forest/TreeTransformScope.scala
+++ b/shared/src/main/scala/cps/macros/forest/TreeTransformScope.scala
@@ -21,7 +21,8 @@ trait TreeTransformScope[F[_]: Type, CT: Type, CC <: CpsMonadContext[F]: Type]
     with SelectOuterTreeTransform[F, CT, CC]
     with BlockTreeTransform[F, CT, CC]
     with ValDefTreeTransform[F, CT, CC]
-    with NonLocalReturnsTreeTransform[F, CT, CC] {
+    with NonLocalReturnsTreeTransform[F, CT, CC]
+    with BreaksTreeTransform[F, CT, CC] {
 
   val cpsCtx: TransformationContext[F, CT, CC]
 

--- a/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
+++ b/shared/src/main/scala/cps/runtime/util/control/BreaksAsyncShift.scala
@@ -6,6 +6,26 @@ import scala.util.control.*
 
 class BreaksAsyncShift extends AsyncShift[Breaks.type] {
 
+  def break(o: Breaks.type): Nothing = {
+    try {
+      Breaks.break()
+    } catch {
+      case ex: ControlThrowable =>
+        throw new ControlThrowableAsyncWrapper(ex)
+    }
+  }
+
+  /** Sync counterpart of `breakable` used by the macro when the body contains no
+    * await but a `NonFatal` substitution was applied. Catches a wrapped break and
+    * delegates to stdlib `Breaks.breakable` to honour identity matching.
+    */
+  def syncBreakable(o: Breaks.type)(op: () => Unit): Unit = {
+    try op()
+    catch
+      case w: ControlThrowableAsyncWrapper =>
+        Breaks.breakable { throw w.ce }
+  }
+
   def breakable[F[_]](o: Breaks.type, m: CpsTryMonad[F])(op: () => F[Unit]): F[Unit] = {
     val opF: F[Unit] =
       try op()
@@ -17,8 +37,11 @@ class BreaksAsyncShift extends AsyncShift[Breaks.type] {
     m.flatMapTry(opF) {
       case Success(v) => m.pure(v)
       case Failure(ex) =>
+        val toThrow = ex match
+          case w: ControlThrowableAsyncWrapper => w.ce
+          case other                           => other
         try {
-          Breaks.breakable { throw ex }
+          Breaks.breakable { throw toThrow }
           m.pure(())
         } catch {
           case NonFatal(ex2) => m.error(ex2)

--- a/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
@@ -77,6 +77,21 @@ class TestBS1ShiftBreaks:
      assertEquals(3, sumBefore)
      assertEquals(0, sumAfter)
 
+  @Test def testBreakableThroughStableAlias(): Unit =
+     val b = Breaks
+     var beforeBreak = 0
+     var afterBreak = 0
+     val c = async[ComputationBound]{
+        b.breakable {
+           beforeBreak = await(T1.cbi(5))
+           b.break()
+           afterBreak = await(T1.cbi(99))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(5, beforeBreak)
+     assertEquals(0, afterBreak)
+
   @Test def testUserNonFatalCatchInsideBodyDoesNotSwallowBreak(): Unit =
      var caught = false
      var afterBreak = 0

--- a/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
+++ b/shared/src/test/scala/cps/TestCBS1ShiftBreaks.scala
@@ -4,7 +4,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.util.{Success, Failure}
-import scala.util.control.Breaks
+import scala.util.control.{Breaks, NonFatal}
 
 import cps.testconfig.given
 
@@ -45,4 +45,52 @@ class TestBS1ShiftBreaks:
      }
      assert(c.run() == Success(()))
      assertEquals(7, beforeBreak)
+     assertEquals(0, afterBreak)
+
+  @Test def testBreakableHonoursBreak(): Unit =
+     var beforeBreak = 0
+     var afterBreak = 0
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           beforeBreak = await(T1.cbi(7))
+           Breaks.break()
+           afterBreak = await(T1.cbi(99))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(7, beforeBreak)
+     assertEquals(0, afterBreak)
+
+  @Test def testBreakableMultipleAwaitsBeforeBreak(): Unit =
+     var sumBefore = 0
+     var sumAfter = 0
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           sumBefore += await(T1.cbi(1))
+           sumBefore += await(T1.cbi(2))
+           Breaks.break()
+           sumAfter += await(T1.cbi(3))
+           sumAfter += await(T1.cbi(4))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(3, sumBefore)
+     assertEquals(0, sumAfter)
+
+  @Test def testUserNonFatalCatchInsideBodyDoesNotSwallowBreak(): Unit =
+     var caught = false
+     var afterBreak = 0
+     val c = async[ComputationBound]{
+        Breaks.breakable {
+           val v = await(T1.cbi(1))
+           try {
+              Breaks.break()
+           } catch {
+              case NonFatal(_) => caught = true
+           }
+           afterBreak = await(T1.cbi(99))
+        }
+     }
+     assert(c.run() == Success(()))
+     assertEquals(false, caught)
      assertEquals(0, afterBreak)


### PR DESCRIPTION
## Summary

Follow-up to #131. The earlier PR fixed `BreaksAsyncShift.breakable` to actually run the monadic body, but `Breaks.break()` thrown from inside a flatMap callback still escaped the monad: `BreakControl extends ControlThrowable`, and `NonFatal`-based catches in runtime monads (e.g. `ComputationBound`) deliberately exclude `ControlThrowable`. So the throw bypassed the shift's failure branch and surfaced from `c.run()` raw.

This PR mirrors the pattern `NonLocalReturns` already uses to solve the identical problem.

### Runtime
- `BreaksAsyncShift.break(o: Breaks.type)`: invokes stdlib `Breaks.break()` inside a try/catch and re-throws as `ControlThrowableAsyncWrapper(ce)` — a plain `Throwable` that `NonFatal` matches. The wrapped `ce` retains the original `BreakControl` instance, so identity matching still works downstream.
- `BreaksAsyncShift.syncBreakable(o)(op)`: sync counterpart used by the macro for sync-changed bodies (mirrors `NonLocalReturnsAsyncShift.syncReturning`).
- `BreaksAsyncShift.breakable` now unwraps `ControlThrowableAsyncWrapper` before delegating to stdlib `Breaks.breakable { throw toThrow }`, restoring the singleton identity match.

### Macro
- New `cps.macros.forest.BreaksTreeTransform` (sibling of `NonLocalReturnsTreeTransform`), mixed into `TreeTransformScope`.
  - `runBreaksBreak(applyTerm)` rewrites `Breaks.break()` → `BreaksAsyncShift.break(Breaks)`.
  - `runBreaksBreakable(applyTerm, fun, args)` rewrites `Breaks.breakable { body }`:
    - async body → `BreaksAsyncShift.breakable[F](Breaks, monad)(asyncLambda)`
    - sync-changed body → `BreaksAsyncShift.syncBreakable(Breaks)(lambda)`
    - sync-unchanged → pass through
  - The body is filtered through `substituteNonFatal` (same `TreeMap` NLR uses) so user `case NonFatal(_)` catches don't accidentally swallow the wrapped break.
- New symbol refs added to `KnownTreeFragments`.
- Two new dispatch cases in `ApplyTreeTransform.runApply`, restricted to the `Breaks` companion by `obj.symbol == breaksModuleSym.companionModule`. Per-instance `new Breaks` calls remain unshifted — explicitly out of scope per #132.

### Tests
`testBreakableHonoursBreak` (which we removed in PR #131 as a known limitation) is re-enabled and passes. Additional regression tests added:
- `testBreakableMultipleAwaitsBeforeBreak` — multiple awaits before/after the break; only prefix runs.
- `testUserNonFatalCatchInsideBodyDoesNotSwallowBreak` — proves the `substituteNonFatal` step works: a user `case NonFatal(_)` inside the body does not catch the wrapped break.

Two pre-existing tests (`testBreakableRunsBody`, `testBreakableHonoursSynchronousBreak`, `testBreakablePropagatesOtherExceptions`) continue to pass.

## Test plan
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftBreaks` — 6 tests pass
- [x] `sbt cpsJVM/test` — 522 tests pass, no regressions

## Out of scope (tracked separately)
- Per-instance `new Breaks` shifting.
- `Breaks.tryBreakable(...)`.
- Refactoring the shared structure between `NonLocalReturnsTreeTransform` and `BreaksTreeTransform` into a common base. Now that we have two concrete examples, this is the next obvious cleanup — to be tackled in a separate, purely structural PR after this merges.

Closes #132

## Base
This PR is stacked on `fix-breaks-asyncshift` (#131). Rebase onto master once #131 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)