### PR TITLE
Hoist substituteNonFatal into KnownTreeFragments

### DIFF
--- a/shared/src/main/scala/cps/macros/forest/BreaksTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/BreaksTreeTransform.scala
@@ -35,16 +35,6 @@ trait BreaksTreeTransform[F[_], CT, CC <: CpsMonadContext[F]]:
       cpsCtx.log("runBreaksBreakable")
     }
     val paramsDescriptor = MethodParamsDescriptor(fun)
-    val substituteNonFatal = new TreeMap {
-      override def transformTree(tree: Tree)(owner: Symbol): Tree = {
-        tree match
-          case u @ Unapply(fun, implicits, patterns) if fun.symbol == nonFatalUnapplySym =>
-            val nFun = Select.unique(nonFatalAndNotControlThrowableAsyncWrapperCompanion, "unapply")
-            Unapply.copy(u)(nFun, implicits, patterns)
-          case _ =>
-            super.transformTree(tree)(owner)
-      }
-    }
     val nArgs = substituteNonFatal.transformTerms(args)(owner)
     val argRecords = O.buildApplyArgsRecords(paramsDescriptor, nArgs)(owner)
     // The single argument is the by-name `op: => Unit`.

--- a/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
+++ b/shared/src/main/scala/cps/macros/forest/KnownTreeFragments.scala
@@ -75,6 +75,23 @@ trait KnownTreeFragments[F[_], CT, CC <: CpsMonadContext[F]]:
   lazy val nonFatalAndNotControlThrowableAsyncWrapperCompanion =
     Ref.term(nonFatalAndNotControlThrowableAsyncWrapperClassSym.companionModule.termRef)
 
+  lazy val nonFatalAndNotControlThrowableAsyncWrapperUnapplyRef =
+    Select.unique(nonFatalAndNotControlThrowableAsyncWrapperCompanion, "unapply")
+
+  /** TreeMap that rewrites `case NonFatal(_)` extractors to use
+    * `NonFatalAndNotControlThrowableAsyncWrapper.unapply`, so a user catch inside a
+    * shifted `breakable` / `returning` body does not swallow the wrapped
+    * `ControlThrowable` we route through the monad.
+    */
+  lazy val substituteNonFatal: TreeMap = new TreeMap {
+    override def transformTree(tree: Tree)(owner: Symbol): Tree =
+      tree match
+        case u @ Unapply(fun, implicits, patterns) if fun.symbol == nonFatalUnapplySym =>
+          Unapply.copy(u)(nonFatalAndNotControlThrowableAsyncWrapperUnapplyRef, implicits, patterns)
+        case _ =>
+          super.transformTree(tree)(owner)
+  }
+
   lazy val logicalAndSym = defn.BooleanClass.declaredMethod("&&").head
   lazy val logicalOrSym = defn.BooleanClass.declaredMethod("||").head
   lazy val logicalNotSym = defn.BooleanClass.declaredMethod("unary_!").head

--- a/shared/src/main/scala/cps/macros/forest/NonLocalReturnsTreeTransform.scala
+++ b/shared/src/main/scala/cps/macros/forest/NonLocalReturnsTreeTransform.scala
@@ -58,16 +58,6 @@ trait NonLocalReturnsTreeTransform[F[_], CT, CC <: CpsMonadContext[F]]:
       cpsCtx.log("runNonLocalReturnsReturning")
     }
     val paramsDescriptor = MethodParamsDescriptor(fun)
-    val substituteNonFatal = new TreeMap {
-      override def transformTree(tree: Tree)(owner: Symbol): Tree = {
-        tree match
-          case u @ Unapply(fun, implicits, patterns) if fun.symbol == nonFatalUnapplySym =>
-            val nFun = Select.unique(nonFatalAndNotControlThrowableAsyncWrapperCompanion, "unapply")
-            Unapply.copy(u)(nFun, implicits, patterns)
-          case _ =>
-            super.transformTree(tree)(owner)
-      }
-    }
     val nArgs = substituteNonFatal.transformTerms(args)(owner)
     val argRecords = O.buildApplyArgsRecords(paramsDescriptor, nArgs)(owner)
     // we have one arg which is lambda by definition of returning


### PR DESCRIPTION
## Summary

Follow-up to #134. `BreaksTreeTransform` and `NonLocalReturnsTreeTransform` each held a byte-for-byte copy of the same `TreeMap` that rewrites `case NonFatal(_)` extractors to the wrapper-aware variant. Lift it into `KnownTreeFragments`, next to the symbols it captures.

While there, cache the `Select.unique(...wrapper..., "unapply")` lookup as its own `lazy val` so it isn't rebuilt for every matching `Unapply` during the tree walk — same precedent as the surrounding `nonFatalAndNotControlThrowableAsyncWrapperCompanion` ref.

### Why not merge the whole transformers?

The 3-way `syncOrigin` / `isChanged` dispatch in `runBreaksBreakable` and `runNonLocalReturnsReturning` is structurally parallel, but every branch diverges in shape:

- **Record kind**: `ApplyArgByNameRecord` (by-name, hand-built `() => Unit` over `syncBody`) vs `ApplyArgLambdaRecord` (`appRecord.generateLambda(...)`).
- **Shifted call shape**: `[F]` vs `[F :: targs]`; `syncBreakable(mod)(...)` vs `syncReturning[T](...)` — different arity in three of four branches.
- **Method lookup**: `Select(objectRef, classMethod)` (Breaks methods live on the class) vs `Ref(objectMethod)` (NLR methods on the singleton).

A generic helper would need ~5 callbacks to paper over those differences — more code than the dispatch saves, and it scatters the rewrite logic across callbacks. Keeping the rewrites local.

### Diff stat
3 files changed, 17 insertions(+), 20 deletions(-).

## Test plan
- [x] `sbt cpsJVM/test` — 523 passed, 0 failed (2 ignored, pre-existing).
- [x] `sbt cpsJVM/testOnly cps.TestBS1ShiftBreaks cpstest.TestCBSReturning cpstest.TestReturningExamples` — 16 passed.

## Base
Stacked on #135 (which brings #134's `BreaksTreeTransform.scala` into master). Retarget to master once #135 lands.